### PR TITLE
feat: Add user service history page

### DIFF
--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -190,4 +190,17 @@ class ServiceController extends AbstractController
             'service' => $service,
         ]);
     }
+
+    #[Route('/mis-servicios', name: 'app_my_services', methods: ['GET'])]
+    public function myServices(ServiceRepository $serviceRepository, \Symfony\Bundle\SecurityBundle\Security $security): Response
+    {
+        $this->denyAccessUnlessGranted('ROLE_VOLUNTEER');
+
+        $user = $security->getUser();
+        $services = $serviceRepository->findServicesByVolunteer($user->getVolunteer());
+
+        return $this->render('service/my_services.html.twig', [
+            'services' => $services,
+        ]);
+    }
 }

--- a/src/Repository/ServiceRepository.php
+++ b/src/Repository/ServiceRepository.php
@@ -55,4 +55,17 @@ class ServiceRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    public function findServicesByVolunteer($volunteer): array
+    {
+        return $this->createQueryBuilder('s')
+            ->innerJoin('s.assistanceConfirmations', 'ac')
+            ->andWhere('ac.volunteer = :volunteer')
+            ->andWhere('ac.hasAttended = :hasAttended')
+            ->setParameter('volunteer', $volunteer)
+            ->setParameter('hasAttended', true)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
 }

--- a/templates/dashboard/volunteer_dashboard.html.twig
+++ b/templates/dashboard/volunteer_dashboard.html.twig
@@ -6,6 +6,13 @@
 <div class="p-6 space-y-6">
     
 <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
+            <h3 class="text-lg font-semibold text-gray-900 mb-4">Mis Servicios</h3>
+            <p class="text-gray-600 mb-4">Consulta el historial de servicios que has realizado.</p>
+            <a href="{{ path('app_my_services') }}" class="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+                Ver mis servicios
+            </a>
+        </div>
+<div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
             <h3 class="text-lg font-semibold text-gray-900 mb-4">Próximos Eventos</h3>
             <div class="space-y-4">
                 <div class="border border-gray-200 rounded-lg p-4">

--- a/templates/service/my_services.html.twig
+++ b/templates/service/my_services.html.twig
@@ -1,0 +1,49 @@
+{% extends 'layout/app.html.twig' %}
+
+{% block title %}Mis Servicios{% endblock %}
+
+{% block content %}
+<div class="p-6 space-y-6">
+    <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-6">
+        <div>
+            <h2 class="text-2xl font-bold text-gray-900">Mis Servicios Realizados</h2>
+            <p class="text-gray-600">Aquí puedes ver todos los servicios en los que has participado.</p>
+        </div>
+    </div>
+
+    <div class="bg-white rounded-xl shadow-sm border border-gray-200">
+        <div class="p-4">
+            <table class="w-full">
+                <thead>
+                    <tr class="border-b border-gray-200">
+                        <th class="p-2 text-left text-sm font-semibold text-gray-600">Nombre del Servicio</th>
+                        <th class="p-2 text-left text-sm font-semibold text-gray-600">Día y Hora</th>
+                        <th class="p-2 text-left text-sm font-semibold text-gray-600">Duración Total</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% if services is defined and services is not empty %}
+                        {% for service in services %}
+                            <tr class="border-b border-gray-200">
+                                <td class="p-2 text-sm">{{ service.title }}</td>
+                                <td class="p-2 text-sm">{{ service.startDate ? service.startDate|date('d/m/Y H:i') : 'N/A' }}</td>
+                                <td class="p-2 text-sm">
+                                    {% if service.startDate and service.endDate %}
+                                        {{ service.endDate|date_diff(service.startDate)|format('%h horas %i minutos') }}
+                                    {% else %}
+                                        N/A
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    {% else %}
+                        <tr>
+                            <td colspan="3" class="p-4 text-center text-gray-500">No has participado en ningún servicio todavía.</td>
+                        </tr>
+                    {% endif %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This commit introduces a new page where you can view the history of services they have performed. The page displays a table with the service name, date and time, and total duration.

- I created a new route and controller action to display the services performed by a user.
- I created a new Twig template to render the list of services with the required columns.
- I modified the `ServiceRepository` to add a method that retrieves the services performed by a specific user.
- I added a link to your service history in your dashboard.