### PR TITLE
feat: Display service duration from VolunteerService entity

### DIFF
--- a/src/Controller/FichajeController.php
+++ b/src/Controller/FichajeController.php
@@ -3,7 +3,7 @@
 namespace App\Controller;
 
 use App\Entity\Service;
-use App\Repository\AssistanceConfirmationRepository;
+use App\Entity\VolunteerService;
 use App\Repository\VolunteerRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -14,21 +14,26 @@ use Symfony\Component\Routing\Annotation\Route;
 class FichajeController extends AbstractController
 {
     #[Route('/service/{id}/fichaje', name: 'app_fichaje', methods: ['POST'])]
-    public function fichaje(Request $request, Service $service, EntityManagerInterface $entityManager, VolunteerRepository $volunteerRepository, AssistanceConfirmationRepository $assistanceConfirmationRepository): Response
+    public function fichaje(Request $request, Service $service, EntityManagerInterface $entityManager, VolunteerRepository $volunteerRepository): Response
     {
         $data = $request->request->all();
         $startTime = new \DateTime($data['start-time']);
         $endTime = new \DateTime($data['end-time']);
         $volunteerIds = $data['volunteers'] ?? [];
 
+        $duration = $endTime->getTimestamp() - $startTime->getTimestamp();
+        $durationInMinutes = round($duration / 60);
+
         foreach ($volunteerIds as $volunteerId) {
             $volunteer = $volunteerRepository->find($volunteerId);
             if ($volunteer) {
-                $assistanceConfirmation = $assistanceConfirmationRepository->findOneBy(['volunteer' => $volunteer, 'service' => $service]);
-                if ($assistanceConfirmation) {
-                    $assistanceConfirmation->setCheckIn($startTime);
-                    $assistanceConfirmation->setCheckOut($endTime);
-                }
+                $volunteerService = new VolunteerService();
+                $volunteerService->setVolunteer($volunteer);
+                $volunteerService->setService($service);
+                $volunteerService->setStartTime($startTime);
+                $volunteerService->setEndTime($endTime);
+                $volunteerService->setDuration($durationInMinutes);
+                $entityManager->persist($volunteerService);
             }
         }
 

--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -192,15 +192,15 @@ class ServiceController extends AbstractController
     }
 
     #[Route('/mis-servicios', name: 'app_my_services', methods: ['GET'])]
-    public function myServices(\App\Repository\AssistanceConfirmationRepository $assistanceConfirmationRepository, \Symfony\Bundle\SecurityBundle\Security $security): Response
+    public function myServices(\App\Repository\VolunteerServiceRepository $volunteerServiceRepository, \Symfony\Bundle\SecurityBundle\Security $security): Response
     {
         $this->denyAccessUnlessGranted('ROLE_VOLUNTEER');
 
         $user = $security->getUser();
-        $assistanceConfirmations = $assistanceConfirmationRepository->findBy(['volunteer' => $user->getVolunteer(), 'hasAttended' => true]);
+        $volunteerServices = $volunteerServiceRepository->findBy(['volunteer' => $user->getVolunteer()]);
 
         return $this->render('service/my_services.html.twig', [
-            'assistanceConfirmations' => $assistanceConfirmations,
+            'volunteerServices' => $volunteerServices,
         ]);
     }
 }

--- a/src/Entity/AssistanceConfirmation.php
+++ b/src/Entity/AssistanceConfirmation.php
@@ -24,12 +24,6 @@ class AssistanceConfirmation
     #[ORM\JoinColumn(nullable: false)]
     private ?Volunteer $volunteer = null;
 
-    #[ORM\Column(type: 'datetime', nullable: true)]
-    private ?\DateTimeInterface $checkIn = null;
-
-    #[ORM\Column(type: 'datetime', nullable: true)]
-    private ?\DateTimeInterface $checkOut = null;
-
     public function getId(): ?int
     {
         return $this->id;
@@ -67,30 +61,6 @@ class AssistanceConfirmation
     public function setVolunteer(?Volunteer $volunteer): static
     {
         $this->volunteer = $volunteer;
-
-        return $this;
-    }
-
-    public function getCheckIn(): ?\DateTimeInterface
-    {
-        return $this->checkIn;
-    }
-
-    public function setCheckIn(?\DateTimeInterface $checkIn): static
-    {
-        $this->checkIn = $checkIn;
-
-        return $this;
-    }
-
-    public function getCheckOut(): ?\DateTimeInterface
-    {
-        return $this->checkOut;
-    }
-
-    public function setCheckOut(?\DateTimeInterface $checkOut): static
-    {
-        $this->checkOut = $checkOut;
 
         return $this;
     }

--- a/templates/service/my_services.html.twig
+++ b/templates/service/my_services.html.twig
@@ -22,14 +22,14 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% if assistanceConfirmations is defined and assistanceConfirmations is not empty %}
-                        {% for confirmation in assistanceConfirmations %}
+                    {% if volunteerServices is defined and volunteerServices is not empty %}
+                        {% for volunteerService in volunteerServices %}
                             <tr class="border-b border-gray-200">
-                                <td class="p-2 text-sm">{{ confirmation.service.title }}</td>
-                                <td class="p-2 text-sm">{{ confirmation.checkIn ? confirmation.checkIn|date('d/m/Y H:i') : 'N/A' }}</td>
+                                <td class="p-2 text-sm">{{ volunteerService.service.title }}</td>
+                                <td class="p-2 text-sm">{{ volunteerService.startTime ? volunteerService.startTime|date('d/m/Y H:i') : 'N/A' }}</td>
                                 <td class="p-2 text-sm">
-                                    {% if confirmation.checkIn and confirmation.checkOut %}
-                                        {{ confirmation.checkOut|date_diff(confirmation.checkIn)|format('%h horas %i minutos') }}
+                                    {% if volunteerService.duration %}
+                                        {{ volunteerService.duration }} minutos
                                     {% else %}
                                         N/A
                                     {% endif %}


### PR DESCRIPTION
This commit modifies your service history page to display the duration of the service from the `duration` property of the `VolunteerService` entity.

- Modified the `myServices` action in `ServiceController` to fetch the `VolunteerService` objects associated with you and pass them to the Twig template.
- Updated the `my_services.html.twig` template to display the duration from the `VolunteerService` entity.
- Cleaned up unused code by removing the `checkIn` and `checkOut` properties from the `AssistanceConfirmation` entity and reverting the changes in the `FichajeController`.