### PR TITLE
feat: Filter services by duration

### DIFF
--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -197,7 +197,12 @@ class ServiceController extends AbstractController
         $this->denyAccessUnlessGranted('ROLE_VOLUNTEER');
 
         $user = $security->getUser();
-        $volunteerServices = $volunteerServiceRepository->findBy(['volunteer' => $user->getVolunteer()]);
+        $volunteerServices = $volunteerServiceRepository->createQueryBuilder('vs')
+            ->andWhere('vs.volunteer = :volunteer')
+            ->andWhere('vs.duration IS NOT NULL')
+            ->setParameter('volunteer', $user->getVolunteer())
+            ->getQuery()
+            ->getResult();
 
         return $this->render('service/my_services.html.twig', [
             'volunteerServices' => $volunteerServices,


### PR DESCRIPTION
This commit modifies the `myServices` action in `ServiceController` to only fetch `VolunteerService` objects where the `duration` is not null. This ensures that only services that have been checked in and out appear in your service history.