### PR TITLE
feat: Format service duration in h:m format

### DIFF
--- a/templates/service/my_services.html.twig
+++ b/templates/service/my_services.html.twig
@@ -29,7 +29,9 @@
                                 <td class="p-2 text-sm">{{ volunteerService.startTime ? volunteerService.startTime|date('d/m/Y H:i') : 'N/A' }}</td>
                                 <td class="p-2 text-sm">
                                     {% if volunteerService.duration %}
-                                        {{ volunteerService.duration }} minutos
+                                        {% set hours = (volunteerService.duration / 60)|round(0, 'floor') %}
+                                        {% set minutes = volunteerService.duration % 60 %}
+                                        {{ hours ~ 'h ' ~ minutes ~ 'm' }}
                                     {% else %}
                                         N/A
                                     {% endif %}


### PR DESCRIPTION
This commit updates the `my_services.html.twig` template to display the service duration in the format 'h:m' instead of minutes.