### PR TITLE
fix: Correctly filter services by current year

### DIFF
--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -198,9 +198,10 @@ class ServiceController extends AbstractController
 
         $user = $security->getUser();
         $volunteerServices = $volunteerServiceRepository->createQueryBuilder('vs')
+            ->innerJoin('vs.service', 's')
             ->andWhere('vs.volunteer = :volunteer')
             ->andWhere('vs.duration IS NOT NULL')
-            ->andWhere('vs.startTime >= :start_of_year')
+            ->andWhere('s.startDate >= :start_of_year')
             ->setParameter('volunteer', $user->getVolunteer())
             ->setParameter('start_of_year', new \DateTime(date('Y-01-01')))
             ->getQuery()


### PR DESCRIPTION
This commit fixes the query in the `myServices` action to correctly filter the services by the current year. The query now joins the `VolunteerService` entity with the `Service` entity and uses the `startDate` of the `Service` for the comparison.