### PR TITLE
feat: Add visual indicator for last service date

### DIFF
--- a/templates/service/my_services.html.twig
+++ b/templates/service/my_services.html.twig
@@ -15,7 +15,30 @@
                 <p class="text-gray-600">Aquí puedes ver todos los servicios en los que has participado.</p>
             {% endif %}
             {% if lastService is defined and lastService is not null %}
-                <p class="text-gray-600">Último servicio: {{ lastService.service.title }} ({{ lastService.startTime|date('d/m/Y') }})</p>
+                {% set now = "now"|date("U") %}
+                {% set lastServiceTime = lastService.startTime|date("U") %}
+                {% set diff = (now - lastServiceTime) / (24 * 3600) %}
+                <p class="text-gray-600">
+                    Último servicio:
+                    <span class="
+                        {% if diff > 90 %}
+                            text-red-500
+                        {% elseif diff > 60 %}
+                            text-yellow-500
+                        {% else %}
+                            text-green-500
+                        {% endif %}
+                    ">
+                        {{ lastService.service.title }} ({{ lastService.startTime|date('d/m/Y') }})
+                    </span>
+                    {% if diff > 90 %}
+                        <span class="text-red-500">- Ha superado el tiempo mínimo de servicios.</span>
+                    {% elseif diff > 60 %}
+                        <span class="text-yellow-500">- Le falta un mes para cumplir los tres meses.</span>
+                    {% else %}
+                        <span class="text-green-500">- ¡Gracias por su colaboración!</span>
+                    {% endif %}
+                </p>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
This commit adds a visual indicator to the last service date in the user's service history page. The date is displayed in red, yellow, or green, with a corresponding message, based on how long ago the service was performed.