### PR TITLE
Feat: Simplify volunteer UI

### DIFF
--- a/templates/dashboard/volunteer_dashboard.html.twig
+++ b/templates/dashboard/volunteer_dashboard.html.twig
@@ -1,22 +1,27 @@
 {% extends 'layout/app.html.twig' %}
 
-{% block title %}Listado de Servicios{% endblock %}
+{% block title %}Dashboard del Voluntario{% endblock %}
 
 {% block content %}
 <div class="p-6 space-y-6">
-
-<div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
             <h3 class="text-lg font-semibold text-gray-900 mb-4">Mis Servicios</h3>
-            <p class="text-gray-600 mb-4">Consulta el historial de servicios que has realizado.</p>
+            <p class="text-gray-600 mb-4">Consulta el historial de servicios que has realizado y confirma tu asistencia.</p>
             <a href="{{ path('app_my_services') }}" class="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
                 Ver mis servicios
             </a>
         </div>
-<div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4">Servicios Disponibles</h3>
-    <p class="text-gray-600 mb-4">Consulta los servicios disponibles y apúntate.</p>
-    <a href="{{ path('app_service_calendar') }}" class="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
-        Ver servicios
-    </a>
+        <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
+            <h3 class="text-lg font-semibold text-gray-900 mb-4">Servicios Disponibles</h3>
+            <p class="text-gray-600 mb-4">Consulta los próximos servicios disponibles y apúntate a los que te interesen.</p>
+            <a href="{{ path('app_service_calendar') }}" class="inline-flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors">
+                Ver calendario de servicios
+            </a>
+        </div>
+    </div>
+
+    {# Aquí puedes añadir más contenido para el dashboard del voluntario si es necesario #}
+
 </div>
-    {% endblock %}
+{% endblock %}

--- a/templates/layout/sidebar.html.twig
+++ b/templates/layout/sidebar.html.twig
@@ -19,28 +19,6 @@
                 <span class="text-sm">Inicio</span>
             </a>
 
-            {# Menú de Acceso Rápido solo para ROLE_VOLUNTEER #}
-            {% if is_granted('ROLE_VOLUNTEER') %}
-            <div class="mb-1">
-                <div class="flex items-center gap-3 px-3 py-2 text-gray-700 cursor-pointer" onclick="toggleSubmenu('quick-access')">
-                    <i data-lucide="zap" class="w-5 h-5"></i> {# Icono para Acceso Rápido #}
-                    <span class="flex-1 text-sm">Acceso rápido</span>
-                    <i data-lucide="chevron-down" class="w-4 h-4" id="quick-access-icon"></i>
-                </div>
-                <div class="ml-4 space-y-1" id="quick-access-submenu" style="display: block;">
-                    <a href="{{ path('app_services_list') }}"
-                       class="flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200 text-gray-700 hover:bg-gray-100">
-                        <i data-lucide="briefcase" class="w-4 h-4"></i>
-                        <span class="text-sm">Servicios</span>
-                    </a>
-                    <a href="{{ path('app_my_services') }}"
-                       class="flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200 text-gray-700 hover:bg-gray-100">
-                        <i data-lucide="star" class="w-4 h-4"></i>
-                        <span class="text-sm">Mis servicios</span>
-                    </a>
-                </div>
-            </div>
-            {% endif %}
 
             {% if not is_granted('ROLE_VOLUNTEER') %}
             <div class="mb-1">
@@ -85,6 +63,7 @@
             </div>
             {% endif %}
 
+            {% if not is_granted('ROLE_VOLUNTEER') %}
             <div class="mb-1">
                 <div class="flex items-center gap-3 px-3 py-2 text-gray-700 cursor-pointer" onclick="toggleSubmenu('servicios')">
                     <i data-lucide="building" class="w-5 h-5"></i>
@@ -112,6 +91,7 @@
                     {% endif %}
                 </div>
             </div>
+            {% endif %}
 
             {% if not is_granted('ROLE_VOLUNTEER') %}
             <a href="{{ path('app_gesdoc') }}"


### PR DESCRIPTION
- Hides 'Acceso rápido' and 'Servicios' menu items from the sidebar for users with the `ROLE_VOLUNTEER`.
- Reorganizes the volunteer dashboard to display service cards in a responsive two-column grid at the top of the page.