### PR TITLE
Fix: Restore mobile menu button

### DIFF
--- a/templates/layout/app.html.twig
+++ b/templates/layout/app.html.twig
@@ -10,6 +10,11 @@
     
     <!-- Main content -->
     <div class="flex-1 flex flex-col overflow-hidden">
+        <header class="bg-white shadow-sm border-b border-gray-200 px-4 py-2 lg:hidden">
+             <button id="sidebar-toggle" class="p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">
+                <i data-lucide="menu" class="w-6 h-6"></i>
+            </button>
+        </header>
         <!-- Main content area -->
         <main class="flex-1 overflow-y-auto">
             {% for message in app.flashes('success') %}


### PR DESCRIPTION
The mobile menu toggle button was accidentally removed in a previous commit that deleted the header template. This change re-introduces the button into the main layout (`app.html.twig`) to restore the mobile navigation functionality.