### PR TITLE
Fix: Make calendar day headers responsive

### DIFF
--- a/templates/service/calendar.html.twig
+++ b/templates/service/calendar.html.twig
@@ -35,13 +35,13 @@
         {% endfor %}
 
         <div class="grid grid-cols-7 gap-2 text-center">
-            <div class="font-bold">Lunes</div>
-            <div class="font-bold">Martes</div>
-            <div class="font-bold">Miércoles</div>
-            <div class="font-bold">Jueves</div>
-            <div class="font-bold">Viernes</div>
-            <div class="font-bold">Sábado</div>
-            <div class="font-bold">Domingo</div>
+            <div class="font-bold"><span class="hidden sm:inline">Lunes</span><span class="sm:hidden">L</span></div>
+            <div class="font-bold"><span class="hidden sm:inline">Martes</span><span class="sm:hidden">M</span></div>
+            <div class="font-bold"><span class="hidden sm:inline">Miércoles</span><span class="sm:hidden">X</span></div>
+            <div class="font-bold"><span class="hidden sm:inline">Jueves</span><span class="sm:hidden">J</span></div>
+            <div class="font-bold"><span class="hidden sm:inline">Viernes</span><span class="sm:hidden">V</span></div>
+            <div class="font-bold"><span class="hidden sm:inline">Sábado</span><span class="sm:hidden">S</span></div>
+            <div class="font-bold"><span class="hidden sm:inline">Domingo</span><span class="sm:hidden">D</span></div>
 
             {% for i in 1..first_day_of_month-1 %}
                 <div></div>


### PR DESCRIPTION
On small viewports, the day-of-the-week headers in the service calendar would overlap. This change uses responsive utility classes to display single-letter abbreviations on small screens and full day names on larger screens, resolving the UI bug.