### PR TITLE
Feat: Use WhatsApp 'Click to Chat' for sharing

### DIFF
--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -308,10 +308,24 @@ class ServiceController extends AbstractController
             $attendUrl = $urlGenerator->generate('app_service_attend', ['id' => $service->getId()], \Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL);
             $unattendUrl = $urlGenerator->generate('app_service_unattend', ['id' => $service->getId()], \Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL);
 
+            $startDate = $service->getStartDate() ? $service->getStartDate()->format('d/m/Y H:i') : 'N/D';
+            $endDate = $service->getEndDate() ? $service->getEndDate()->format('d/m/Y H:i') : 'N/D';
+
+            $message = sprintf(
+                "*¡Nuevo Servicio Disponible!*\n\n*Servicio:* %s\n*Fecha de Inicio:* %s\n*Fecha de Fin:* %s\n\nPor favor, confirma tu asistencia:\n\n*QUIERO ASISTIR:*\n%s\n\n*NO PUEDO ASISTIR:*\n%s",
+                $service->getTitle(),
+                $startDate,
+                $endDate,
+                $attendUrl,
+                $unattendUrl
+            );
+
+            $whatsAppUrl = 'https://wa.me/?text=' . urlencode($message);
+
             return $this->render('service/share.html.twig', [
                 'service' => $service,
-                'attend_url' => $attendUrl,
-                'unattend_url' => $unattendUrl,
+                'whatsapp_url' => $whatsAppUrl,
+                'raw_message' => $message
             ]);
         }
 }

--- a/templates/service/share.html.twig
+++ b/templates/service/share.html.twig
@@ -8,64 +8,16 @@
         <h1 class="text-2xl font-bold mb-2">Compartir Servicio</h1>
         <p class="text-gray-600 mb-6">Copia el siguiente mensaje y pégalo en tu grupo de WhatsApp para notificar a los voluntarios.</p>
 
-        <div id="share-message" class="bg-gray-100 p-4 rounded-lg border border-gray-200 whitespace-pre-wrap font-mono text-sm">
-*¡Nuevo Servicio Disponible!*
-
-*Servicio:* {{ service.title }}
-*Fecha de Inicio:* {{ service.startDate ? service.startDate|date('d/m/Y H:i') : 'N/D' }}
-*Fecha de Fin:* {{ service.endDate ? service.endDate|date('d/m/Y H:i') : 'N/D' }}
-
-Por favor, confirma tu asistencia:
-
-*QUIERO ASISTIR:*
-{{ attend_url }}
-
-*NO PUEDO ASISTIR:*
-{{ unattend_url }}
+        <div class="bg-gray-100 p-4 rounded-lg border border-gray-200 whitespace-pre-wrap font-mono text-sm">
+{{ raw_message|nl2br|raw }}
         </div>
 
-        <button id="copy-button" class="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors">
-            <i data-lucide="copy" class="w-4 h-4"></i>
-            Copiar Mensaje
-        </button>
-        <span id="copy-success" class="ml-4 text-green-600 hidden font-medium">¡Copiado!</span>
+        <a href="{{ whatsapp_url }}"
+           target="_blank"
+           class="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition-colors">
+            <i data-lucide="send" class="w-4 h-4"></i>
+            Compartir en WhatsApp
+        </a>
     </div>
 </div>
-{% endblock %}
-
-{% block javascripts %}
-    {{ parent() }}
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            const copyButton = document.getElementById('copy-button');
-            const shareMessage = document.getElementById('share-message');
-            const successMessage = document.getElementById('copy-success');
-
-            if (copyButton && shareMessage) {
-                copyButton.addEventListener('click', function() {
-                    // Usar innerText para preservar los saltos de línea que WhatsApp entiende
-                    const textToCopy = shareMessage.innerText;
-
-                    navigator.clipboard.writeText(textToCopy).then(() => {
-                        // Éxito al copiar
-                        successMessage.classList.remove('hidden');
-                        copyButton.classList.add('bg-green-600', 'hover:bg-green-700');
-                        copyButton.innerHTML = '<i data-lucide="check" class="w-4 h-4"></i> Copiado';
-                        lucide.createIcons(); // Re-renderizar el ícono
-
-                        setTimeout(() => {
-                            successMessage.classList.add('hidden');
-                            copyButton.classList.remove('bg-green-600', 'hover:bg-green-700');
-                            copyButton.innerHTML = '<i data-lucide="copy" class="w-4 h-4"></i> Copiar Mensaje';
-                            lucide.createIcons(); // Re-renderizar el ícono
-                        }, 2500);
-
-                    }).catch(err => {
-                        console.error('Error al copiar el texto: ', err);
-                        alert('Error al copiar el mensaje. Por favor, cópialo manualmente.');
-                    });
-                });
-            }
-        });
-    </script>
 {% endblock %}


### PR DESCRIPTION
- Updates the `ServiceController::share` action to build and URL-encode the full message text.
- Generates a `https://wa.me/` link with the pre-filled text.
- Replaces the copy-paste mechanism in the `share.html.twig` template with a direct link to WhatsApp, improving user experience.