### PR TITLE
Feat: Add detailed fields to Service entity and share message

### DIFF
--- a/migrations/Version20250827043100.php
+++ b/migrations/Version20250827043100.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250827043100 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add has_supplies, sva_count, svb_count, and responsible_person to service table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE service ADD has_supplies TINYINT(1) DEFAULT 0 NOT NULL, ADD sva_count INT DEFAULT NULL, ADD svb_count INT DEFAULT NULL, ADD responsible_person VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE service DROP has_supplies, DROP sva_count, DROP svb_count, DROP responsible_person');
+    }
+}

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -78,6 +78,18 @@ class Service
     #[ORM\OneToMany(mappedBy: 'service', targetEntity: AssistanceConfirmation::class, orphanRemoval: true)]
     private Collection $assistanceConfirmations;
 
+    #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
+    private bool $hasSupplies = false;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $svaCount = null;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $svbCount = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $responsiblePerson = null;
+
     public function __construct()
     {
         $this->assistanceConfirmations = new ArrayCollection();
@@ -313,6 +325,54 @@ class Service
                 $assistanceConfirmation->setService(null);
             }
         }
+
+        return $this;
+    }
+
+    public function isHasSupplies(): ?bool
+    {
+        return $this->hasSupplies;
+    }
+
+    public function setHasSupplies(bool $hasSupplies): static
+    {
+        $this->hasSupplies = $hasSupplies;
+
+        return $this;
+    }
+
+    public function getSvaCount(): ?int
+    {
+        return $this->svaCount;
+    }
+
+    public function setSvaCount(?int $svaCount): static
+    {
+        $this->svaCount = $svaCount;
+
+        return $this;
+    }
+
+    public function getSvbCount(): ?int
+    {
+        return $this->svbCount;
+    }
+
+    public function setSvbCount(?int $svbCount): static
+    {
+        $this->svbCount = $svbCount;
+
+        return $this;
+    }
+
+    public function getResponsiblePerson(): ?string
+    {
+        return $this->responsiblePerson;
+    }
+
+    public function setResponsiblePerson(?string $responsiblePerson): static
+    {
+        $this->responsiblePerson = $responsiblePerson;
 
         return $this;
     }

--- a/src/Form/ServiceType.php
+++ b/src/Form/ServiceType.php
@@ -131,6 +131,25 @@ class ServiceType extends AbstractType
             ->add('requester', TextType::class, [
                 'label' => 'Solicitante',
                 'required' => false,
+            ])
+            ->add('hasSupplies', CheckboxType::class, [
+                'label' => 'Avituallamiento Disponible',
+                'required' => false,
+            ])
+            ->add('svaCount', IntegerType::class, [
+                'label' => 'Nº Ambulancias SVA',
+                'required' => false,
+                'attr' => ['min' => 0, 'placeholder' => '0'],
+            ])
+            ->add('svbCount', IntegerType::class, [
+                'label' => 'Nº Ambulancias SVB',
+                'required' => false,
+                'attr' => ['min' => 0, 'placeholder' => '0'],
+            ])
+            ->add('responsiblePerson', TextType::class, [
+                'label' => 'Responsable del Servicio',
+                'required' => false,
+                'attr' => ['placeholder' => 'Nombre del responsable'],
             ]);
     }
 


### PR DESCRIPTION
- Adds `hasSupplies`, `svaCount`, `svbCount`, and `responsiblePerson` fields to the `Service` entity.
- Creates a new database migration to add these columns to the `service` table.
- Updates the `ServiceType` form to include inputs for the new fields.
- Reworks the `ServiceController::share` action to generate a new, detailed message format for WhatsApp using the new entity properties.