### PR TITLE
Feat: Add self-service profile editing for volunteers

### DIFF
--- a/src/Form/ProfileType.php
+++ b/src/Form/ProfileType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Volunteer;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use App\Form\UserType;
+
+class ProfileType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            // --- Datos Personales (No editables) ---
+            ->add('name', TextType::class, [
+                'label' => 'Nombre Completo',
+                'disabled' => true,
+            ])
+            ->add('lastName', TextType::class, [
+                'label' => 'Apellidos',
+                'disabled' => true,
+            ])
+            ->add('dni', TextType::class, [
+                'label' => 'DNI',
+                'disabled' => true,
+            ])
+            ->add('dateOfBirth', DateType::class, [
+                'label' => 'Fecha de Nacimiento',
+                'widget' => 'single_text',
+                'html5' => true,
+                'disabled' => true,
+            ])
+
+            // --- Rol y Especialización (No editables) ---
+            ->add('role', TextType::class, [
+                'label' => 'Rol en la Organización',
+                'disabled' => true,
+            ])
+            ->add('specialization', TextType::class, [
+                'label' => 'Especialización',
+                'disabled' => true,
+            ])
+
+            // --- Datos de Acceso (Contraseña editable) ---
+            ->add('user', UserType::class, [
+                'label' => 'Datos de Acceso',
+                'by_reference' => true,
+                'is_edit' => true, // Forzar modo edición para el sub-formulario de usuario
+            ])
+
+            // --- Campos Editables ---
+            ->add('phone', TextType::class, [
+                'label' => 'Teléfono de Contacto',
+                'attr' => ['placeholder' => 'Ej: +34 600 123 456'],
+            ])
+            ->add('streetType', ChoiceType::class, [
+                'label' => 'Tipo de Vía',
+                'choices' => [
+                    'Calle' => 'Calle', 'Avenida' => 'Avenida', 'Plaza' => 'Plaza',
+                    'Paseo' => 'Paseo', 'Ronda' => 'Ronda', 'Vía' => 'Via',
+                    'Carretera' => 'Carretera', 'Camino' => 'Camino', 'Bulevar' => 'Bulevar',
+                    'Glorieta' => 'Glorieta', 'Urbanización' => 'Urbanización',
+                    'Bloque' => 'Bloque', 'Edificio' => 'Edificio', 'Otro' => 'Otro',
+                ],
+                'placeholder' => 'Selecciona un tipo de vía',
+                'required' => false,
+            ])
+            ->add('address', TextType::class, [
+                'label' => 'Dirección',
+                'attr' => ['placeholder' => 'Ej: Gran Vía, 10, 3º A'],
+                'required' => false,
+            ])
+            ->add('postalCode', TextType::class, [
+                'label' => 'Código Postal',
+                'attr' => ['placeholder' => 'Ej: 28001'],
+                'required' => false,
+            ])
+            ->add('province', TextType::class, [
+                'label' => 'Provincia',
+                'attr' => ['placeholder' => 'Ej: Madrid'],
+                'required' => false,
+            ])
+            ->add('city', TextType::class, [
+                'label' => 'Población',
+                'attr' => ['placeholder' => 'Ej: Madrid'],
+                'required' => false,
+            ])
+            ->add('contactPerson1', TextType::class, [
+                'label' => 'Contacto de Emergencia 1',
+                'attr' => ['placeholder' => 'Ej: María Pérez'],
+                'required' => false,
+            ])
+            ->add('contactPhone1', TextType::class, [
+                'label' => 'Teléfono de Emergencia 1',
+                'attr' => ['placeholder' => 'Ej: +34 600 987 654'],
+                'required' => false,
+            ])
+            ->add('allergies', TextareaType::class, [
+                'label' => 'Alergias / Consideraciones de Salud',
+                'attr' => ['placeholder' => 'Especificar tipo y precauciones.'],
+                'required' => false,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Volunteer::class,
+        ]);
+    }
+}

--- a/templates/layout/sidebar.html.twig
+++ b/templates/layout/sidebar.html.twig
@@ -19,6 +19,14 @@
                 <span class="text-sm">Inicio</span>
             </a>
 
+            {% if is_granted('ROLE_VOLUNTEER') %}
+            <a href="{{ path('app_profile_edit') }}"
+               class="flex items-center gap-3 px-3 py-2 rounded-lg transition-all duration-200 {{ current_section|default('') == 'perfil' ? 'bg-blue-100 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-100' }}">
+                <i data-lucide="user-cog" class="w-5 h-5"></i>
+                <span class="text-sm">Mi Perfil</span>
+            </a>
+            {% endif %}
+
 
             {% if not is_granted('ROLE_VOLUNTEER') %}
             <div class="mb-1">

--- a/templates/volunteer/edit_profile.html.twig
+++ b/templates/volunteer/edit_profile.html.twig
@@ -1,0 +1,71 @@
+{% extends 'layout/app.html.twig' %}
+
+{% block title %}Editar Mi Perfil{% endblock %}
+
+{% block content %}
+<div class="p-6">
+    <div class="bg-white p-8 rounded-2xl shadow-lg max-w-4xl mx-auto">
+        <h1 class="text-3xl font-bold mb-2 text-gray-800">Editar Mi Perfil</h1>
+        <p class="text-gray-500 mb-8">Actualiza tu información de contacto y tu contraseña.</p>
+
+        {{ form_start(form) }}
+
+        <div class="space-y-8">
+            {# --- Sección de Acceso --- #}
+            <div>
+                <h2 class="text-xl font-semibold mb-4 border-b pb-2">Datos de Acceso</h2>
+                {{ form_row(form.user) }}
+            </div>
+
+            {# --- Sección de Contacto Editable --- #}
+            <div>
+                <h2 class="text-xl font-semibold mb-4 border-b pb-2">Información de Contacto</h2>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    {{ form_row(form.phone) }}
+                    {{ form_row(form.streetType) }}
+                    {{ form_row(form.address) }}
+                    {{ form_row(form.city) }}
+                    {{ form_row(form.province) }}
+                    {{ form_row(form.postalCode) }}
+                </div>
+            </div>
+
+            {# --- Sección de Contacto de Emergencia --- #}
+            <div>
+                <h2 class="text-xl font-semibold mb-4 border-b pb-2">Contacto de Emergencia</h2>
+                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    {{ form_row(form.contactPerson1) }}
+                    {{ form_row(form.contactPhone1) }}
+                </div>
+            </div>
+
+            {# --- Sección de Salud --- #}
+            <div>
+                 <h2 class="text-xl font-semibold mb-4 border-b pb-2">Salud</h2>
+                {{ form_row(form.allergies) }}
+            </div>
+
+            {# --- Sección de Datos No Editables --- #}
+            <div>
+                <h2 class="text-xl font-semibold mb-4 border-b pb-2 text-gray-500">Información Fija (No editable)</h2>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6 bg-gray-50 p-6 rounded-lg">
+                    {{ form_row(form.name) }}
+                    {{ form_row(form.lastName) }}
+                    {{ form_row(form.dni) }}
+                    {{ form_row(form.dateOfBirth) }}
+                    {{ form_row(form.role) }}
+                    {{ form_row(form.specialization) }}
+                </div>
+            </div>
+        </div>
+
+        <div class="mt-8 pt-6 border-t">
+            <button type="submit" class="w-full md:w-auto px-8 py-3 bg-blue-600 text-white font-bold rounded-lg hover:bg-blue-700 transition-all duration-300">
+                Guardar Cambios
+            </button>
+        </div>
+
+        {{ form_end(form) }}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
- Creates a new `ProfileType` form with disabled fields for restricted data (name, DNI, role, etc.) to allow volunteers to edit only permitted information.
- Adds an `editProfile` action to `VolunteerController` to handle the form and update the user's profile and password.
- Creates a new `edit_profile.html.twig` template for the edit page.
- Adds a 'Mi Perfil' link to the sidebar, visible only to users with `ROLE_VOLUNTEER`.