### PR TITLE
Feat: Implement full, read-only profile form for volunteers

### DIFF
--- a/src/Form/ProfileType.php
+++ b/src/Form/ProfileType.php
@@ -3,15 +3,15 @@
 namespace App\Form;
 
 use App\Entity\Volunteer;
+use App\Form\UserType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use App\Form\UserType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProfileType extends AbstractType
 {
@@ -20,7 +20,7 @@ class ProfileType extends AbstractType
         $builder
             // --- Datos Personales (No editables) ---
             ->add('name', TextType::class, [
-                'label' => 'Nombre Completo',
+                'label' => 'Nombre Completo del Voluntario',
                 'disabled' => true,
             ])
             ->add('lastName', TextType::class, [
@@ -38,21 +38,22 @@ class ProfileType extends AbstractType
                 'disabled' => true,
             ])
 
-            // --- Rol y Especialización (No editables) ---
-            ->add('role', TextType::class, [
+            // --- Rol (No editable) ---
+            ->add('role', ChoiceType::class, [
                 'label' => 'Rol en la Organización',
-                'disabled' => true,
-            ])
-            ->add('specialization', TextType::class, [
-                'label' => 'Especialización',
+                'choices' => [
+                    'Voluntario' => 'Voluntario',
+                    'Coordinador' => 'Coordinador',
+                    'Especialista' => 'Especialista',
+                ],
                 'disabled' => true,
             ])
 
             // --- Datos de Acceso (Contraseña editable) ---
             ->add('user', UserType::class, [
-                'label' => 'Datos de Acceso',
+                'label' => 'Datos de Acceso (Email y Contraseña)',
                 'by_reference' => true,
-                'is_edit' => true, // Forzar modo edición para el sub-formulario de usuario
+                'is_edit' => true, // Siempre es edición en el perfil
             ])
 
             // --- Campos Editables ---
@@ -63,17 +64,16 @@ class ProfileType extends AbstractType
             ->add('streetType', ChoiceType::class, [
                 'label' => 'Tipo de Vía',
                 'choices' => [
-                    'Calle' => 'Calle', 'Avenida' => 'Avenida', 'Plaza' => 'Plaza',
-                    'Paseo' => 'Paseo', 'Ronda' => 'Ronda', 'Vía' => 'Via',
-                    'Carretera' => 'Carretera', 'Camino' => 'Camino', 'Bulevar' => 'Bulevar',
-                    'Glorieta' => 'Glorieta', 'Urbanización' => 'Urbanización',
+                    'Calle' => 'Calle', 'Avenida' => 'Avenida', 'Plaza' => 'Plaza', 'Paseo' => 'Paseo',
+                    'Ronda' => 'Ronda', 'Vía' => 'Via', 'Carretera' => 'Carretera', 'Camino' => 'Camino',
+                    'Bulevar' => 'Bulevar', 'Glorieta' => 'Glorieta', 'Urbanización' => 'Urbanización',
                     'Bloque' => 'Bloque', 'Edificio' => 'Edificio', 'Otro' => 'Otro',
                 ],
                 'placeholder' => 'Selecciona un tipo de vía',
                 'required' => false,
             ])
             ->add('address', TextType::class, [
-                'label' => 'Dirección',
+                'label' => 'Nombre de la Vía, Número, Piso, Puerta',
                 'attr' => ['placeholder' => 'Ej: Gran Vía, 10, 3º A'],
                 'required' => false,
             ])
@@ -93,19 +93,115 @@ class ProfileType extends AbstractType
                 'required' => false,
             ])
             ->add('contactPerson1', TextType::class, [
-                'label' => 'Contacto de Emergencia 1',
+                'label' => 'Nombre de Persona de Contacto 1 (Emergencia)',
                 'attr' => ['placeholder' => 'Ej: María Pérez'],
                 'required' => false,
             ])
             ->add('contactPhone1', TextType::class, [
-                'label' => 'Teléfono de Emergencia 1',
+                'label' => 'Teléfono de Contacto 1 (Emergencia)',
                 'attr' => ['placeholder' => 'Ej: +34 600 987 654'],
                 'required' => false,
             ])
-            ->add('allergies', TextareaType::class, [
-                'label' => 'Alergias / Consideraciones de Salud',
-                'attr' => ['placeholder' => 'Especificar tipo y precauciones.'],
+            ->add('contactPerson2', TextType::class, [
+                'label' => 'Nombre de Persona de Contacto 2 (Opcional)',
+                'attr' => ['placeholder' => 'Ej: Pedro Gómez'],
                 'required' => false,
+            ])
+            ->add('contactPhone2', TextType::class, [
+                'label' => 'Teléfono de Contacto 2 (Opcional)',
+                'attr' => ['placeholder' => 'Ej: +34 600 111 222'],
+                'required' => false,
+            ])
+            ->add('allergies', TextareaType::class, [
+                'label' => 'Alergias / Consideraciones de Salud (Opcional)',
+                'attr' => ['placeholder' => 'Ej: Alergia al polen, Diabético. Especificar tipo y precauciones.'],
+                'required' => false,
+            ])
+            ->add('profession', TextType::class, [
+                'label' => 'Profesión',
+                'attr' => ['placeholder' => 'Ej: Médico, Ingeniero, Estudiante'],
+                'required' => false,
+            ])
+            ->add('employmentStatus', ChoiceType::class, [
+                'label' => 'Situación Laboral',
+                'choices' => [
+                    'Activo' => 'Activo', 'Desempleado' => 'Desempleado', 'Estudiante' => 'Estudiante',
+                    'Jubilado' => 'Jubilado', 'Otro' => 'Otro',
+                ],
+                'placeholder' => 'Selecciona una opción',
+                'required' => false,
+            ])
+            ->add('drivingLicenses', ChoiceType::class, [
+                'label' => 'Permiso de Conducción',
+                'choices' => [
+                    'A1' => 'A1', 'A' => 'A', 'B' => 'B', 'C1' => 'C1', 'C' => 'C',
+                    'D1' => 'D1', 'D' => 'D', 'EC' => 'EC',
+                ],
+                'multiple' => true,
+                'expanded' => true,
+                'required' => false,
+            ])
+            ->add('drivingLicenseExpiryDate', DateType::class, [
+                'label' => 'Fecha de Caducidad del Permiso de Conducción',
+                'widget' => 'single_text',
+                'html5' => true,
+                'required' => false,
+            ])
+            ->add('languages', TextareaType::class, [
+                'label' => 'Idiomas (indicar nivel: bajo, medio o alto)',
+                'attr' => ['placeholder' => 'Ej: Inglés: alto, Francés: medio'],
+                'required' => false,
+            ])
+            ->add('motivation', TextareaType::class, [
+                'label' => 'Motivaciones',
+                'disabled' => true,
+            ])
+            ->add('howKnown', TextType::class, [
+                'label' => '¿Cómo nos conoció?',
+                'disabled' => true,
+            ])
+            ->add('hasVolunteeredBefore', ChoiceType::class, [
+                'label' => '¿Ha sido voluntario antes?',
+                'choices' => ['Sí' => true, 'No' => false],
+                'expanded' => true,
+                'disabled' => true,
+            ])
+            ->add('previousVolunteeringInstitutions', TextareaType::class, [
+                'label' => 'Instituciones de voluntariado anteriores',
+                'disabled' => true,
+            ])
+            ->add('otherQualifications', TextareaType::class, [
+                'label' => 'Otras Titulaciones',
+                'disabled' => true,
+            ])
+            ->add('navigationLicenses', ChoiceType::class, [
+                'label' => 'Permisos de Navegación',
+                'choices' => [
+                    'Licencia de Navegación (LN)' => 'LN', 'Patrón de Navegación Básica (PNB)' => 'PNB',
+                    'Patrón de Embarcaciones de Recreo (PER)' => 'PER', 'Patrón de Yate (PY)' => 'PY',
+                    'Capitán de Yate (CY)' => 'CY',
+                ],
+                'multiple' => true,
+                'expanded' => true,
+                'required' => false,
+            ])
+            ->add('specificQualifications', ChoiceType::class, [
+                'label' => 'Titulaciones Específicas',
+                'choices' => [
+                    'Técnico en Emergencias Sanitarias de Grado Medio' => 'TecnicoEmergencias',
+                    'Certificado de profesionalidad de transporte sanitario' => 'CertificadoTransporteSanitario',
+                    'Título universitario de Enfermería válido en España' => 'TituloEnfermeria',
+                    'Acreditación del registro de enfermeros de transporte sanitario de la Comunidad de Madrid (DUEM)' => 'AcreditacionDUEM',
+                    'Título universitario de Medicina válido en España' => 'TituloMedicina',
+                    'Acreditación del registro de médicos de transporte sanitario de la Comunidad de Madrid (FUEM)' => 'AcreditacionFUEM',
+                ],
+                'multiple' => true,
+                'expanded' => true,
+                'required' => false,
+            ])
+            ->add('specialization', TextType::class, [
+                'label' => 'Especialización',
+                'disabled' => true,
             ]);
     }
 


### PR DESCRIPTION
- Replaces the previous, simplified `ProfileType` with a complete form that mirrors the admin view.
- Disables sensitive fields (name, DNI, role, etc.) to prevent modification by the volunteer.
- Ensures contact information and password remain editable.