### PR TITLE
Fix: Conditionally render profile picture field in template

### DIFF
--- a/templates/volunteer/edit_volunteer.html.twig
+++ b/templates/volunteer/edit_volunteer.html.twig
@@ -33,7 +33,8 @@
         {# CONTENEDOR PRINCIPAL: Flex para la fila superior (foto + datos básicos) #}
         <div class="flex flex-col md:flex-row gap-6 mb-8">
 
-            {# Recuadro de la foto de perfil (Izquierda - md:w-1/2) #}
+            {# Recuadro de la foto de perfil (Izquierda - md:w-1/2) - Solo si el campo existe en el formulario #}
+            {% if form.profilePicture is defined %}
             <div class="w-full md:w-1/2 p-4 border border-gray-200 rounded-lg text-center bg-gray-50">
                 <h3 class="text-xl font-semibold mb-4 text-gray-800">Foto de Perfil</h3>
                 <div class="mb-4">
@@ -60,6 +61,7 @@
                 </div>
                 <p class="text-xs text-gray-500 mt-1">Sube una imagen JPG o PNG (máx. 1MB).</p>
             </div>
+            {% endif %}
 
             {# Recuadro de Datos Básicos (Derecha - md:w-1/2) #}
             <div class="w-full md:w-1/2 p-4 border border-gray-200 rounded-lg bg-white">


### PR DESCRIPTION
- Wraps the profile picture section in `edit_volunteer.html.twig` in an `if form.profilePicture is defined` condition.
- This prevents a Twig runtime error when the page is rendered with `ProfileType`, which does not contain this field.