### PR TITLE
fix: Crear el fichero de formulario AssistanceConfirmationType que fa…

### DIFF
--- a/src/Form/AssistanceConfirmationType.php
+++ b/src/Form/AssistanceConfirmationType.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\AssistanceConfirmation;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AssistanceConfirmationType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('checkInTime', DateTimeType::class, [
+                'label' => 'Hora de Entrada',
+                'widget' => 'single_text',
+                'required' => false,
+                'html5' => false,
+                'format' => 'HH:mm',
+            ])
+            ->add('checkOutTime', DateTimeType::class, [
+                'label' => 'Hora de Salida',
+                'widget' => 'single_text',
+                'required' => false,
+                'html5' => false,
+                'format' => 'HH:mm',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => AssistanceConfirmation::class,
+        ]);
+    }
+}


### PR DESCRIPTION
…ltaba

Este commit corrige el error `Could not load type "App\Form\AssistanceConfirmationType": class does not exist.`

El error ocurría porque el fichero `src/Form/AssistanceConfirmationType.php` fue eliminado accidentalmente durante un reinicio del código y no se volvió a crear.

Este commit añade el fichero que faltaba, permitiendo que el `ServiceType` lo utilice en su campo de `CollectionType` y que el autoloader de Composer pueda registrar la clase.