### PR TITLE
fix: Añadir propiedades y getters/setters a AssistanceConfirmation

### DIFF
--- a/src/Entity/AssistanceConfirmation.php
+++ b/src/Entity/AssistanceConfirmation.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Repository\AssistanceConfirmationRepository;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: AssistanceConfirmationRepository::class)]
@@ -15,6 +16,12 @@ class AssistanceConfirmation
 
     #[ORM\Column]
     private ?bool $hasAttended = null;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    private ?\DateTimeInterface $checkInTime = null;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    private ?\DateTimeInterface $checkOutTime = null;
 
     #[ORM\ManyToOne(inversedBy: 'assistanceConfirmations')]
     #[ORM\JoinColumn(nullable: false)]
@@ -61,6 +68,30 @@ class AssistanceConfirmation
     public function setVolunteer(?Volunteer $volunteer): static
     {
         $this->volunteer = $volunteer;
+
+        return $this;
+    }
+
+    public function getCheckInTime(): ?\DateTimeInterface
+    {
+        return $this->checkInTime;
+    }
+
+    public function setCheckInTime(?\DateTimeInterface $checkInTime): static
+    {
+        $this->checkInTime = $checkInTime;
+
+        return $this;
+    }
+
+    public function getCheckOutTime(): ?\DateTimeInterface
+    {
+        return $this->checkOutTime;
+    }
+
+    public function setCheckOutTime(?\DateTimeInterface $checkOutTime): static
+    {
+        $this->checkOutTime = $checkOutTime;
 
         return $this;
     }


### PR DESCRIPTION
Este commit corrige el error `NoSuchPropertyException` que ocurría porque las propiedades `checkInTime` y `checkOutTime`, junto con sus métodos `getter` y `setter`, no existían en la entidad `AssistanceConfirmation`.

Al parecer, estas modificaciones se perdieron durante un reinicio del código. Este commit restaura la entidad a su estado correcto, añadiendo:
- Las propiedades `checkInTime` y `checkOutTime` con el tipo `DATETIME_MUTABLE`.
- Los métodos públicos `getCheckInTime`, `setCheckInTime`, `getCheckOutTime` y `setCheckOutTime`.

Esto permite que el componente `PropertyAccessor` de Symfony pueda leer y escribir en estas propiedades al construir y manejar el formulario, lo que resuelve el error.