### PR TITLE
fix: Update sidebar JS to support Turbo navigation

### DIFF
--- a/templates/layout/sidebar.html.twig
+++ b/templates/layout/sidebar.html.twig
@@ -169,9 +169,16 @@
     }
 </style>
 <script>
-    document.addEventListener('DOMContentLoaded', function () {
+    function setupSidebar() {
         const submenuItems = document.querySelectorAll('.has-submenu');
         submenuItems.forEach(item => {
+            // Remove existing listeners to avoid duplicates
+            item.replaceWith(item.cloneNode(true));
+        });
+
+        // Re-query the items after cloning
+        const newSubmenuItems = document.querySelectorAll('.has-submenu');
+        newSubmenuItems.forEach(item => {
             item.addEventListener('mouseenter', function () {
                 this.classList.add('submenu-open');
             });
@@ -180,5 +187,8 @@
                 this.classList.remove('submenu-open');
             });
         });
-    });
+    }
+
+    document.addEventListener('turbo:load', setupSidebar);
+    document.addEventListener('DOMContentLoaded', setupSidebar);
 </script>


### PR DESCRIPTION
This commit fixes a bug where the sidebar menu's hover functionality would stop working after navigating to a new page using Symfony Turbo.

- The JavaScript event listeners are now re-attached on the `turbo:load` event, ensuring the menu works correctly after page transitions.
- The setup logic is encapsulated in a `setupSidebar` function.
- A mechanism to prevent duplicate event listeners has been included.