### PR TITLE
feat: Add volunteer ID and update styles on edit form

### DIFF
--- a/templates/volunteer/edit_volunteer.html.twig
+++ b/templates/volunteer/edit_volunteer.html.twig
@@ -56,8 +56,12 @@
             </div>
 
             {# Recuadro de Datos Básicos (Derecha - md:w-1/2) #}
-            <div class="w-full md:w-1/2 p-4 border border-gray-200 rounded-lg bg-white">
+            <div class="w-full md:w-1/2 p-4 border border-gray-200 rounded-lg bg-gray-50">
                 <h3 class="text-xl font-semibold mb-4 text-gray-800">Datos Básicos</h3>
+                <div class="mb-4">
+                    <span class="block text-sm font-medium text-gray-700">ID Voluntario</span>
+                    <span class="text-lg font-semibold text-gray-900">{{ volunteer.id }}</span>
+                </div>
                 <div class="grid grid-cols-2 gap-x-6">
                     <!-- Fila 1: Nombre y Apellidos -->
                     <div class="col-span-1">


### PR DESCRIPTION
This commit adds two enhancements to the "Edit Volunteer" form based on user feedback:

- The volunteer's ID is now displayed at the top of the "Datos Básicos" section.
- The background color of the "Datos Básicos" section has been changed to `bg-gray-50` to match the style of the adjacent profile picture section.