### PR TITLE
feat: Add comprehensive toolbar to CKEditor on new service page

### DIFF
--- a/templates/service/new_service.html.twig
+++ b/templates/service/new_service.html.twig
@@ -88,11 +88,12 @@
             if (document.getElementById(editorId)) {
                 CKEDITOR.replace(editorId, {
                     toolbar: [
-                        { name: 'basicstyles', items: [ 'Bold', 'Italic', 'Strike', '-', 'Superscript', 'Subscript', '-', 'RemoveFormat' ] },
+                        { name: 'document', items: [ 'Source' ] },
+                        { name: 'basicstyles', items: [ 'Bold', 'Italic', 'Strike', 'Superscript', 'Subscript', '-', 'RemoveFormat' ] },
                         { name: 'paragraph', items: [ 'NumberedList', 'BulletedList', '-', 'JustifyLeft', 'JustifyCenter', 'JustifyRight' ] },
+                        { name: 'links', items: [ 'Link', 'Unlink' ] },
                         { name: 'insert', items: [ 'HorizontalRule' ] },
-                        { name: 'styles', items: [ 'Format' ] },
-                        { name: 'document', items: [ 'Source' ] }
+                        { name: 'styles', items: [ 'Format' ] }
                     ]
                 });
             }


### PR DESCRIPTION
This commit updates the CKEditor configuration on the new service page to include a comprehensive set of toolbar buttons as requested by the user.

The toolbar now explicitly includes all requested formatting options:
- Source view
- Bold, Italic, Strikethrough, Superscript, Subscript
- Link and Unlink
- Left, Center, and Right alignment
- Ordered and Unordered lists
- Horizontal Rule
- Remove Format

This ensures that users have all the necessary tools for creating rich descriptions for services.