### PR TITLE
feat: Update styles and editor for Create New Service form

### DIFF
--- a/templates/service/new_service.html.twig
+++ b/templates/service/new_service.html.twig
@@ -5,11 +5,12 @@
 {% block stylesheets %}
     {{ parent() }}
     <style>
-        label.required {
-            color: red;
+        label {
+            color: black;
         }
         label.required:after {
             content: " *";
+            color: red;
         }
     </style>
 {% endblock %}
@@ -89,6 +90,7 @@
                 CKEDITOR.replace(editorId, {
                     toolbar: [
                         { name: 'document', items: [ 'Source' ] },
+                        { name: 'clipboard', items: [ 'Undo', 'Redo' ] },
                         { name: 'basicstyles', items: [ 'Bold', 'Italic', 'Strike', 'Superscript', 'Subscript', '-', 'RemoveFormat' ] },
                         { name: 'paragraph', items: [ 'NumberedList', 'BulletedList', '-', 'JustifyLeft', 'JustifyCenter', 'JustifyRight' ] },
                         { name: 'links', items: [ 'Link', 'Unlink' ] },


### PR DESCRIPTION
This commit addresses the user's request to update the styling of the "Crear Nuevo Servicio" form.

The following changes have been made in `templates/service/new_service.html.twig`:

1.  The CSS for form labels has been modified. All labels now appear in black text, and required fields are marked with a red asterisk, as requested.
2.  The CKEditor toolbar for the 'description' field has been updated to include the 'Undo' and 'Redo' buttons to fully match the user's requirements.