### PR TITLE
fix: Add custom link sanitizer to Quill.js

### DIFF
--- a/templates/service/new_service.html.twig
+++ b/templates/service/new_service.html.twig
@@ -23,6 +23,20 @@
     {{ parent() }}
     <script src="https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.js"></script>
     <script>
+        // --- Custom Link Sanitizer for Quill ---
+        const Link = Quill.import('formats/link');
+        class CustomLink extends Link {
+            static sanitize(url) {
+                const sanitizedUrl = super.sanitize(url);
+                if (sanitizedUrl && sanitizedUrl !== 'about:blank' && !/^(https?:\/\/|mailto:|tel:)/.test(sanitizedUrl)) {
+                    return 'https://' + sanitizedUrl;
+                }
+                return sanitizedUrl;
+            }
+        }
+        Quill.register(CustomLink, true);
+        // --- End Custom Link Sanitizer ---
+
         let quillInstance = null;
 
         function initializeQuillEditor() {


### PR DESCRIPTION
This commit fixes an issue where the Quill.js editor was creating relative links for URLs entered without a protocol (e.g., "www.google.com").

A custom link sanitizer has been added to `templates/service/new_service.html.twig`. This script extends Quill's default `Link` format and overrides the `sanitize` method to automatically prepend `https://` to any link that is missing a protocol. This ensures all links created in the editor are absolute and point to the correct external resources.