### PR TITLE
feat: Add detailed fields to Service form

### DIFF
--- a/migrations/Version20250904045100.php
+++ b/migrations/Version20250904045100.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250904045100 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add new fields to service table for detailed service information';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE service ADD afluencia VARCHAR(255) DEFAULT NULL, ADD num_svb INT DEFAULT NULL, ADD num_sva INT DEFAULT NULL, ADD num_svae INT DEFAULT NULL, ADD num_medical INT DEFAULT NULL, ADD has_field_hospital TINYINT(1) DEFAULT NULL, ADD tasks LONGTEXT DEFAULT NULL, ADD has_provisions TINYINT(1) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE service DROP afluencia, DROP num_svb, DROP num_sva, DROP num_svae, DROP num_medical, DROP has_field_hospital, DROP tasks, DROP has_provisions');
+    }
+}

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -78,6 +78,30 @@ class Service
     #[ORM\OneToMany(mappedBy: 'service', targetEntity: AssistanceConfirmation::class, orphanRemoval: true)]
     private Collection $assistanceConfirmations;
 
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $afluencia = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $numSvb = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $numSva = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $numSvae = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $numMedical = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?bool $hasFieldHospital = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $tasks = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?bool $hasProvisions = null;
+
     public function __construct()
     {
         $this->assistanceConfirmations = new ArrayCollection();
@@ -313,6 +337,102 @@ class Service
                 $assistanceConfirmation->setService(null);
             }
         }
+
+        return $this;
+    }
+
+    public function getAfluencia(): ?string
+    {
+        return $this->afluencia;
+    }
+
+    public function setAfluencia(?string $afluencia): static
+    {
+        $this->afluencia = $afluencia;
+
+        return $this;
+    }
+
+    public function getNumSvb(): ?int
+    {
+        return $this->numSvb;
+    }
+
+    public function setNumSvb(?int $numSvb): static
+    {
+        $this->numSvb = $numSvb;
+
+        return $this;
+    }
+
+    public function getNumSva(): ?int
+    {
+        return $this->numSva;
+    }
+
+    public function setNumSva(?int $numSva): static
+    {
+        $this->numSva = $numSva;
+
+        return $this;
+    }
+
+    public function getNumSvae(): ?int
+    {
+        return $this->numSvae;
+    }
+
+    public function setNumSvae(?int $numSvae): static
+    {
+        $this->numSvae = $numSvae;
+
+        return $this;
+    }
+
+    public function getNumMedical(): ?int
+    {
+        return $this->numMedical;
+    }
+
+    public function setNumMedical(?int $numMedical): static
+    {
+        $this->numMedical = $numMedical;
+
+        return $this;
+    }
+
+    public function isHasFieldHospital(): ?bool
+    {
+        return $this->hasFieldHospital;
+    }
+
+    public function setHasFieldHospital(?bool $hasFieldHospital): static
+    {
+        $this->hasFieldHospital = $hasFieldHospital;
+
+        return $this;
+    }
+
+    public function getTasks(): ?string
+    {
+        return $this->tasks;
+    }
+
+    public function setTasks(?string $tasks): static
+    {
+        $this->tasks = $tasks;
+
+        return $this;
+    }
+
+    public function isHasProvisions(): ?bool
+    {
+        return $this->hasProvisions;
+    }
+
+    public function setHasProvisions(?bool $hasProvisions): static
+    {
+        $this->hasProvisions = $hasProvisions;
 
         return $this;
     }

--- a/src/Form/ServiceType.php
+++ b/src/Form/ServiceType.php
@@ -104,6 +104,48 @@ class ServiceType extends AbstractType
                 'multiple' => true,
                 'expanded' => true, // Render as checkboxes
                 'required' => false,
+            ])
+            ->add('locality', TextType::class, [
+                'label' => 'Lugar',
+                'required' => false,
+            ])
+            ->add('afluencia', ChoiceType::class, [
+                'label' => 'Afluencia',
+                'choices' => [
+                    'Baja' => 'baja',
+                    'Media' => 'media',
+                    'Alta' => 'alta',
+                ],
+                'placeholder' => 'Selecciona un nivel',
+                'required' => false,
+            ])
+            ->add('numSvb', IntegerType::class, [
+                'label' => 'Ambulancias SVB',
+                'required' => false,
+            ])
+            ->add('numSva', IntegerType::class, [
+                'label' => 'Ambulancias SVA',
+                'required' => false,
+            ])
+            ->add('numSvae', IntegerType::class, [
+                'label' => 'Ambulancias SVAE',
+                'required' => false,
+            ])
+            ->add('numMedical', IntegerType::class, [
+                'label' => 'Médico y/o Enfermería',
+                'required' => false,
+            ])
+            ->add('hasFieldHospital', CheckboxType::class, [
+                'label' => 'Hospital de Campaña',
+                'required' => false,
+            ])
+            ->add('tasks', TextareaType::class, [
+                'label' => 'Tareas',
+                'required' => false,
+            ])
+            ->add('hasProvisions', CheckboxType::class, [
+                'label' => 'Avituallamiento',
+                'required' => false,
             ]);
     }
 

--- a/templates/service/new_service.html.twig
+++ b/templates/service/new_service.html.twig
@@ -99,70 +99,137 @@
         <div class="bg-white shadow-md rounded-lg p-6 mb-8">
             {{ form_start(serviceForm) }}
 
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {# Columna 1 #}
                 <div>
-                    {{ form_label(serviceForm.numeration, null, {'label_attr': {'class': 'block mb-2'}}) }}
-                    {{ form_widget(serviceForm.numeration) }}
-                    {{ form_errors(serviceForm.numeration) }}
+                    <div>
+                        {{ form_label(serviceForm.numeration, null, {'label_attr': {'class': 'block mb-2'}}) }}
+                        {{ form_widget(serviceForm.numeration) }}
+                        {{ form_errors(serviceForm.numeration) }}
+                    </div>
+                    <div class="mt-4">
+                        {{ form_label(serviceForm.title, null, {'label_attr': {'class': 'block mb-2'}}) }}
+                        {{ form_widget(serviceForm.title) }}
+                        {{ form_errors(serviceForm.title) }}
+                    </div>
+                    <div class="mt-4">
+                        {{ form_label(serviceForm.locality, 'Lugar 📍', {'label_attr': {'class': 'block mb-2'}}) }}
+                        {{ form_widget(serviceForm.locality) }}
+                        {{ form_errors(serviceForm.locality) }}
+                    </div>
+                    <div class="mt-4">
+                        {{ form_label(serviceForm.afluencia, 'Afluencia 📈', {'label_attr': {'class': 'block mb-2'}}) }}
+                        {{ form_widget(serviceForm.afluencia) }}
+                        {{ form_errors(serviceForm.afluencia) }}
+                    </div>
                 </div>
+
+                {# Columna 2 #}
                 <div>
-                    {{ form_label(serviceForm.title, null, {'label_attr': {'class': 'block mb-2'}}) }}
-                    {{ form_widget(serviceForm.title) }}
-                    {{ form_errors(serviceForm.title) }}
+                    <div>
+                        {{ form_label(serviceForm.startDate, null, {'label_attr': {'class': 'block mb-2'}}) }}
+                        {{ form_widget(serviceForm.startDate) }}
+                        {{ form_errors(serviceForm.startDate) }}
+                    </div>
+                    <div class="mt-4">
+                        {{ form_label(serviceForm.endDate, null, {'label_attr': {'class': 'block mb-2'}}) }}
+                        {{ form_widget(serviceForm.endDate) }}
+                        {{ form_errors(serviceForm.endDate) }}
+                    </div>
+                    <div class="mt-4">
+                        {{ form_label(serviceForm.registrationLimitDate, null, {'label_attr': {'class': 'block mb-2'}}) }}
+                        {{ form_widget(serviceForm.registrationLimitDate) }}
+                        {{ form_errors(serviceForm.registrationLimitDate) }}
+                    </div>
+                    <div class="mt-4">
+                        {{ form_label(serviceForm.maxAttendees, null, {'label_attr': {'class': 'block mb-2'}}) }}
+                        {{ form_widget(serviceForm.maxAttendees) }}
+                        {{ form_errors(serviceForm.maxAttendees) }}
+                    </div>
                 </div>
+
+                {# Columna 3 #}
                 <div>
-                    {{ form_label(serviceForm.startDate, null, {'label_attr': {'class': 'block mb-2'}}) }}
-                    {{ form_widget(serviceForm.startDate) }}
-                    {{ form_errors(serviceForm.startDate) }}
+                    <div>
+                        {{ form_label(serviceForm.timeAtBase, null, {'label_attr': {'class': 'block mb-2'}}) }}
+                        {{ form_widget(serviceForm.timeAtBase) }}
+                        {{ form_errors(serviceForm.timeAtBase) }}
+                    </div>
+                    <div class="mt-4">
+                        {{ form_label(serviceForm.departureTime, null, {'label_attr': {'class': 'block mb-2'}}) }}
+                        {{ form_widget(serviceForm.departureTime) }}
+                        {{ form_errors(serviceForm.departureTime) }}
+                    </div>
+                    <div class="mt-4">
+                        {{ form_label(serviceForm.type, null, {'label_attr': {'class': 'block mb-2'}}) }}
+                        {{ form_widget(serviceForm.type) }}
+                        {{ form_errors(serviceForm.type) }}
+                        <a href="#" class="text-sm text-blue-600 hover:underline mt-2 block">
+                            <i data-lucide="plus-circle" class="inline-block w-4 h-4 mr-1" style="vertical-align: -2px;"></i>
+                            Añadir nuevo tipo
+                        </a>
+                    </div>
+                    <div class="mt-4">
+                        {{ form_label(serviceForm.category, null, {'label_attr': {'class': 'block mb-2'}}) }}
+                        {{ form_widget(serviceForm.category) }}
+                        {{ form_errors(serviceForm.category) }}
+                        <a href="#" class="text-sm text-blue-600 hover:underline mt-2 block">
+                            <i data-lucide="plus-circle" class="inline-block w-4 h-4 mr-1" style="vertical-align: -2px;"></i>
+                            Añadir nueva categoría
+                        </a>
+                    </div>
                 </div>
-                <div>
-                    {{ form_label(serviceForm.endDate, null, {'label_attr': {'class': 'block mb-2'}}) }}
-                    {{ form_widget(serviceForm.endDate) }}
-                    {{ form_errors(serviceForm.endDate) }}
+
+                {# Fila de Recursos #}
+                <div class="lg:col-span-3">
+                    <h3 class="text-lg font-semibold mb-2 border-b pb-1">Recursos y Tareas</h3>
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                        <div>
+                            {{ form_label(serviceForm.numSvb, 'Ambulancias SVB 🚑', {'label_attr': {'class': 'block mb-2'}}) }}
+                            {{ form_widget(serviceForm.numSvb) }}
+                            {{ form_errors(serviceForm.numSvb) }}
+                        </div>
+                        <div>
+                            {{ form_label(serviceForm.numSva, 'Ambulancias SVA 🚑', {'label_attr': {'class': 'block mb-2'}}) }}
+                            {{ form_widget(serviceForm.numSva) }}
+                            {{ form_errors(serviceForm.numSva) }}
+                        </div>
+                        <div>
+                            {{ form_label(serviceForm.numSvae, 'Ambulancias SVAE 🚑', {'label_attr': {'class': 'block mb-2'}}) }}
+                            {{ form_widget(serviceForm.numSvae) }}
+                            {{ form_errors(serviceForm.numSvae) }}
+                        </div>
+                        <div>
+                            {{ form_label(serviceForm.numMedical, 'Médico/Enfermería 🥼🩺', {'label_attr': {'class': 'block mb-2'}}) }}
+                            {{ form_widget(serviceForm.numMedical) }}
+                            {{ form_errors(serviceForm.numMedical) }}
+                        </div>
+                        <div class="flex items-center pt-6">
+                            {{ form_widget(serviceForm.hasFieldHospital) }}
+                            {{ form_label(serviceForm.hasFieldHospital, 'Hospital de Campaña 🏥', {'label_attr': {'class': 'ml-2'}}) }}
+                            {{ form_errors(serviceForm.hasFieldHospital) }}
+                        </div>
+                        <div class="flex items-center pt-6">
+                            {{ form_widget(serviceForm.hasProvisions) }}
+                            {{ form_label(serviceForm.hasProvisions, 'Avituallamiento 🥪', {'label_attr': {'class': 'ml-2'}}) }}
+                            {{ form_errors(serviceForm.hasProvisions) }}
+                        </div>
+                    </div>
                 </div>
-                <div>
-                    {{ form_label(serviceForm.registrationLimitDate, null, {'label_attr': {'class': 'block mb-2'}}) }}
-                    {{ form_widget(serviceForm.registrationLimitDate) }}
-                    {{ form_errors(serviceForm.registrationLimitDate) }}
-                </div>
-                <div>
-                    {{ form_label(serviceForm.maxAttendees, null, {'label_attr': {'class': 'block mb-2'}}) }}
-                    {{ form_widget(serviceForm.maxAttendees) }}
-                    {{ form_errors(serviceForm.maxAttendees) }}
-                </div>
-                <div>
-                    {{ form_label(serviceForm.timeAtBase, null, {'label_attr': {'class': 'block mb-2'}}) }}
-                    {{ form_widget(serviceForm.timeAtBase) }}
-                    {{ form_errors(serviceForm.timeAtBase) }}
-                </div>
-                <div>
-                    {{ form_label(serviceForm.departureTime, null, {'label_attr': {'class': 'block mb-2'}}) }}
-                    {{ form_widget(serviceForm.departureTime) }}
-                    {{ form_errors(serviceForm.departureTime) }}
-                </div>
-                <div>
-                    {{ form_label(serviceForm.type, null, {'label_attr': {'class': 'block mb-2'}}) }}
-                    {{ form_widget(serviceForm.type) }}
-                    {{ form_errors(serviceForm.type) }}
-                    <a href="#" class="text-sm text-blue-600 hover:underline mt-2 block">
-                        <i data-lucide="plus-circle" class="inline-block w-4 h-4 mr-1" style="vertical-align: -2px;"></i>
-                        Añadir nuevo tipo
-                    </a>
-                </div>
-                <div>
-                    {{ form_label(serviceForm.category, null, {'label_attr': {'class': 'block mb-2'}}) }}
-                    {{ form_widget(serviceForm.category) }}
-                    {{ form_errors(serviceForm.category) }}
-                    <a href="#" class="text-sm text-blue-600 hover:underline mt-2 block">
-                        <i data-lucide="plus-circle" class="inline-block w-4 h-4 mr-1" style="vertical-align: -2px;"></i>
-                        Añadir nueva categoría
-                    </a>
-                </div>
-                <div class="md:col-span-2">
-                    {{ form_label(serviceForm.description, null, {'label_attr': {'class': 'block mb-2'}}) }}
-                    <div id="quill-editor"></div>
-                    {{ form_widget(serviceForm.description, {'id': 'description_editor', 'attr': {'style': 'display:none;'}}) }}
-                    {{ form_errors(serviceForm.description) }}
+
+                {# Fila de Tareas y Descripción #}
+                <div class="lg:col-span-3 grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div>
+                        {{ form_label(serviceForm.tasks, 'Tareas 📝', {'label_attr': {'class': 'block mb-2'}}) }}
+                        {{ form_widget(serviceForm.tasks, {'attr': {'rows': '10'}}) }}
+                        {{ form_errors(serviceForm.tasks) }}
+                    </div>
+                    <div>
+                        {{ form_label(serviceForm.description, 'Descripción ℹ️', {'label_attr': {'class': 'block mb-2'}}) }}
+                        <div id="quill-editor"></div>
+                        {{ form_widget(serviceForm.description, {'id': 'description_editor', 'attr': {'style': 'display:none;'}}) }}
+                        {{ form_errors(serviceForm.description) }}
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
This commit implements a feature to add several new, detailed fields to the "Create New Service" form, based on user requirements.

The following changes have been made:
1.  **Entity Update:** The `Service` entity (`src/Entity/Service.php`) has been updated with new properties: `afluencia`, `numSvb`, `numSva`, `numSvae`, `numMedical`, `hasFieldHospital`, `tasks`, and `hasProvisions`.
2.  **Database Migration:** A new migration file (`migrations/Version20250904045100.php`) has been created to add the corresponding new columns to the `service` table.
3.  **Form Update:** The `ServiceType` form class (`src/Form/ServiceType.php`) has been updated to include form fields for all the new properties, as well as the existing `locality` property.
4.  **Template Update:** The `new_service.html.twig` template has been updated to render all the new fields in a more organized, multi-column layout, with icons as requested.