### PR TITLE
feat: Add detailed fields and summary page for services

### DIFF
--- a/templates/service/edit_service.html.twig
+++ b/templates/service/edit_service.html.twig
@@ -33,43 +33,69 @@
         </ul>
         <div class="tab-content" id="myTabContent">
             <div class="tab-pane fade show active" id="datos_basicos" role="tabpanel" aria-labelledby="datos_basicos-tab">
-                {{ form_start(form, {'attr': {'class': 'bg-white p-6 rounded-lg shadow-md'}, 'enctype': 'multipart/form-data'}) }}
+                {{ form_start(form, {'attr': {'class': 'bg-white p-6 rounded-lg shadow-md'}}) }}
 
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-                    <div class="col-span-1">
-                        <h3 class="text-lg font-medium text-gray-900 mb-4 border-b pb-2">Datos del Servicio</h3>
-                        <div class="mb-4">
-                            {{ form_row(form.title, {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+                <div class="space-y-8">
+                    {# Row 1 #}
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                        <div>{{ form_row(form.numeration) }}</div>
+                        <div>{{ form_row(form.title) }}</div>
+                        <div>{{ form_row(form.locality) }}</div>
+                    </div>
+
+                    {# Row 2 #}
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                        <div>{{ form_row(form.startDate) }}</div>
+                        <div>{{ form_row(form.timeAtBase) }}</div>
+                        <div>{{ form_row(form.endDate) }}</div>
+                    </div>
+
+                    {# Row 3 #}
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                        <div>{{ form_row(form.registrationLimitDate) }}</div>
+                        <div>{{ form_row(form.type) }}</div>
+                        <div>{{ form_row(form.category) }}</div>
+                    </div>
+
+                    {# Row 4 - Recursos #}
+                    <div>
+                        <h3 class="text-lg font-semibold mb-2 border-b pb-1">Recursos</h3>
+                        <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-6">
+                            <div>{{ form_row(form.afluencia) }}</div>
+                            <div>{{ form_row(form.numSvb) }}</div>
+                            <div>{{ form_row(form.numSva) }}</div>
+                            <div>{{ form_row(form.numSvae) }}</div>
+                            <div>{{ form_row(form.numMedical) }}</div>
+                            <div class="flex items-center pt-6">{{ form_row(form.hasFieldHospital) }}</div>
+                            <div class="flex items-center pt-6">{{ form_row(form.hasProvisions) }}</div>
                         </div>
-                        <div class="mb-4">
-                            {{ form_row(form.numeration, {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+                    </div>
+
+                    {# Row 5 - Tareas y Descripción #}
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div>
+                            {{ form_label(form.tasks) }}
+                            <div id="tasks-editor-edit"></div>
+                            {{ form_widget(form.tasks, {'id': 'tasks_textarea_edit', 'attr': {'style': 'display:none;'}}) }}
+                            {{ form_errors(form.tasks) }}
                         </div>
-                        <div class="mb-4">
-                            {{ form_row(form.startDate, {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+                        <div>
+                            {{ form_label(form.description) }}
+                            <div id="quill-editor-edit"></div>
+                            {{ form_widget(form.description, {'id': 'description_textarea_edit', 'attr': {'style': 'display:none;'}}) }}
+                            {{ form_errors(form.description) }}
                         </div>
-                        <div class="mb-4">
-                            {{ form_row(form.endDate, {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
-                        </div>
-                        <div class="mb-4">
-                            {{ form_row(form.maxAttendees, {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
-                        </div>
-                        <div class="mb-4">
-                            {{ form_row(form.type, {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
-                        </div>
-                        <div class="mb-4">
-                            {{ form_row(form.category, {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
-                        </div>
-                        <div class="mb-4">
-                            {{ form_row(form.description, {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
-                        </div>
-                        <div class="mb-4">
-                            {{ form_row(form.recipients, {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
-                        </div>
+                    </div>
+
+                    {# Row 6 - Recipients #}
+                    <div>
+                        <h3 class="text-lg font-semibold mb-2 border-b pb-1">Destinatarios</h3>
+                        {{ form_row(form.recipients) }}
                     </div>
                 </div>
 
-                <div class="mt-6 text-center">
-                    <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition duration-300 ease-in-out">
+                <div class="mt-8 text-center">
+                    <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg">
                         Guardar Cambios
                     </button>
                 </div>
@@ -114,10 +140,74 @@
 {% endblock %}
 
 {% block javascripts %}
-    {{ parent() }} {# Mantiene cualquier JS que venga del layout padre #}
-
+    {{ parent() }}
+    <script src="https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.js"></script>
     <script>
+        // --- Custom Link Sanitizer for Quill ---
+        const Link = Quill.import('formats/link');
+        class CustomLink extends Link {
+            static sanitize(url) {
+                const sanitizedUrl = super.sanitize(url);
+                if (sanitizedUrl && sanitizedUrl !== 'about:blank' && !/^(https?:\/\/|mailto:|tel:)/.test(sanitizedUrl)) {
+                    return 'https://' + sanitizedUrl;
+                }
+                return sanitizedUrl;
+            }
+        }
+        Quill.register(CustomLink, true);
+        // --- End Custom Link Sanitizer ---
+
+        const quillInstances = {};
+
+        function setupQuill(containerId, textareaId) {
+            const editorContainer = document.querySelector(containerId);
+            const hiddenTextarea = document.querySelector(textareaId);
+
+            if (!editorContainer || !hiddenTextarea || quillInstances[containerId]) {
+                return;
+            }
+
+            const toolbarOptions = [
+                [{ 'header': [1, 2, 3, false] }],
+                ['bold', 'italic', 'strike', 'underline'],
+                [{ 'script': 'sub'}, { 'script': 'super' }],
+                [{ 'list': 'ordered'}, { 'list': 'bullet' }],
+                [{ 'align': [] }],
+                ['link'],
+                ['clean']
+            ];
+
+            const quill = new Quill(editorContainer, {
+                modules: { toolbar: toolbarOptions },
+                theme: 'snow'
+            });
+
+            // Pre-fill editor with existing content
+            quill.root.innerHTML = hiddenTextarea.value;
+
+            quill.on('text-change', function() {
+                hiddenTextarea.value = quill.root.innerHTML;
+            });
+
+            quillInstances[containerId] = quill;
+        }
+
+        function initializeAllQuillEditors() {
+            setupQuill('#quill-editor-edit', '#description_textarea_edit');
+            setupQuill('#tasks-editor-edit', '#tasks_textarea_edit');
+        }
+
+        document.addEventListener('turbo:before-cache', function() {
+            for (const key in quillInstances) {
+                if (quillInstances.hasOwnProperty(key)) {
+                    quillInstances[key] = null;
+                }
+            }
+        });
+
+        document.addEventListener('turbo:load', initializeAllQuillEditors);
         document.addEventListener('DOMContentLoaded', function() {
+            initializeAllQuillEditors();
             const tabsContainer = document.getElementById('myTab');
             const tabContents = document.getElementById('myTabContent');
 

--- a/templates/service/view.html.twig
+++ b/templates/service/view.html.twig
@@ -4,12 +4,44 @@
 
 {% block content %}
 <div class="p-6">
-    <h1 class="text-2xl font-bold mb-4">{{ service.title }}</h1>
     <div class="bg-white p-6 rounded-lg shadow-md">
-        <p><strong>Descripción:</strong> {{ service.description }}</p>
-        <p><strong>Fecha de inicio:</strong> {{ service.startDate ? service.startDate|date('Y-m-d H:i:s') : 'N/A' }}</p>
-        <p><strong>Fecha de fin:</strong> {{ service.endDate ? service.endDate|date('Y-m-d H:i:s') : 'N/A' }}</p>
-        <p><strong>Límite de inscripción:</strong> {{ service.registrationLimitDate ? service.registrationLimitDate|date('Y-m-d H:i:s') : 'N/A' }}</p>
+        <h2 class="text-xl font-bold mb-4 border-b pb-2">Resumen del Servicio para WhatsApp</h2>
+
+        {# Using pre-wrap to respect newlines and spaces from the formatted text #}
+        <div class="whitespace-pre-wrap font-mono text-sm bg-gray-50 p-4 rounded-md">
+            <strong>{{ service.startDate|format_datetime(locale='es', pattern='EEEE d ''de'' MMMM')|capitalize }}</strong>
+            <strong>{{ service.title }}</strong>
+
+            H. Base: {{ service.timeAtBase ? service.timeAtBase|date('H:i') : 'N/A' }}
+            H. Salida: {{ service.departureTime ? service.departureTime|date('H:i') : 'N/A' }}
+            Fin: {{ service.endDate ? service.endDate|date('H:i') : 'N/A' }} aprox
+
+            Descripción:
+            {{ service.description|raw }}
+
+            {% if service.hasProvisions %}
+            Avituallamiento: Sí
+            {% endif %}
+
+            {% if service.afluencia %}
+            Afluencia: {{ service.afluencia|capitalize }} {% if service.afluencia == 'alta' %}🔴{% endif %}
+            {% endif %}
+
+            {% if service.numSvb > 0 or service.numSva > 0 or service.numSvae > 0 %}
+            Ambulancias:
+                {% if service.numSvb > 0 %}> {{ service.numSvb }} SVB 🚑{% endif %}
+                {% if service.numSva > 0 %}> {{ service.numSva }} SVA 🚑{% endif %}
+                {% if service.numSvae > 0 %}> {{ service.numSvae }} SVAE 🚑{% endif %}
+            {% endif %}
+
+            {% if service.numMedical > 0 %}
+            Médico y enfermería: {{ service.numMedical }} 🥼🩺
+            {% endif %}
+
+            {% if service.hasFieldHospital %}
+            Hospital de campaña: Sí 🏥
+            {% endif %}
+        </div>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This commit implements a major feature enhancement for the service management module, based on a series of user requests.

The following changes have been made:
1.  **Entity and Database:** The `Service` entity and database schema have been updated to include several new fields for capturing detailed service information (`afluencia`, ambulance counts, medical staff, etc.). A corresponding database migration is included.
2.  **Forms:** The `ServiceType` form class has been updated to include all new fields.
3.  **Create Service Page (`new_service.html.twig`):**
    *   The form layout has been completely reorganized to match user specifications.
    *   The 'Tareas' field has been converted into a rich text editor (Quill.js).
    *   The 'Recipients' field has been hidden from this view as requested.
    *   The page now correctly extends the main application layout.
4.  **Edit Service Page (`edit_service.html.twig`):**
    *   The template has been updated to render all the new fields, fixing a crash.
    *   The 'Tareas' and 'Descripción' fields are now both rich text editors.
5.  **View Service Page (`view.html.twig`):**
    *   This template now displays a formatted text summary of the service, intended for sharing.
    *   Date formatting now correctly uses Symfony's localization features.
6.  **Rich Text Editor:** The implementation uses Quill.js from a CDN, with a custom link sanitizer to ensure all links are absolute. The initialization script handles two editor instances and is compatible with Turbo Drive.