### PR TITLE
fix: Correct PHP syntax error in date formatter

### DIFF
--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -299,7 +299,7 @@ class ServiceController extends AbstractController
     public function view(Service $service): Response
     {
         // --- Generate WhatsApp Message ---
-        $formatter = new \IntlDateFormatter('es_ES', \IntlDateFormatter::FULL, \IntlDateFormatter::NONE, null, null, 'EEEE d ''de'' MMMM');
+        $formatter = new \IntlDateFormatter('es_ES', \IntlDateFormatter::FULL, \IntlDateFormatter::NONE, null, null, 'EEEE d \'de\' MMMM');
         $dateString = ucfirst($formatter->format($service->getStartDate()));
 
         $message = "*{$dateString}*\n";


### PR DESCRIPTION
This commit fixes a `ParseError` in `ServiceController.php`.

The error was caused by improper escaping of single quotes within the date format pattern string for the `IntlDateFormatter`. The pattern `EEEE d ''de'' MMMM` is valid in Twig but not in a single-quoted PHP string.

The string has been corrected to use a backslash for escaping: `'EEEE d 'de' MMMM'`, which resolves the syntax error.