### PR TITLE
feat: Update new service form layout and fields

### DIFF
--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -91,7 +91,10 @@ class Service
     private ?int $numSvae = null;
 
     #[ORM\Column(nullable: true)]
-    private ?int $numMedical = null;
+    private ?int $numDoctors = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $numNurses = null;
 
     #[ORM\Column(nullable: true)]
     private ?bool $hasFieldHospital = null;
@@ -389,14 +392,26 @@ class Service
         return $this;
     }
 
-    public function getNumMedical(): ?int
+    public function getNumDoctors(): ?int
     {
-        return $this->numMedical;
+        return $this->numDoctors;
     }
 
-    public function setNumMedical(?int $numMedical): static
+    public function setNumDoctors(?int $numDoctors): static
     {
-        $this->numMedical = $numMedical;
+        $this->numDoctors = $numDoctors;
+
+        return $this;
+    }
+
+    public function getNumNurses(): ?int
+    {
+        return $this->numNurses;
+    }
+
+    public function setNumNurses(?int $numNurses): static
+    {
+        $this->numNurses = $numNurses;
 
         return $this;
     }

--- a/src/Form/ServiceType.php
+++ b/src/Form/ServiceType.php
@@ -87,7 +87,7 @@ class ServiceType extends AbstractType
                 'required' => true,
             ])
             ->add('description', TextareaType::class, [
-                'label' => 'Descripción',
+                'label' => 'Decisión',
                 'required' => false,
             ])
             ->add('recipients', ChoiceType::class, [
@@ -130,8 +130,12 @@ class ServiceType extends AbstractType
                 'label' => 'Ambulancias SVAE',
                 'required' => false,
             ])
-            ->add('numMedical', IntegerType::class, [
-                'label' => 'Médico y/o Enfermería',
+            ->add('numDoctors', IntegerType::class, [
+                'label' => 'Médicos',
+                'required' => false,
+            ])
+            ->add('numNurses', IntegerType::class, [
+                'label' => 'Enfermeros',
                 'required' => false,
             ])
             ->add('hasFieldHospital', CheckboxType::class, [

--- a/templates/service/new_service.html.twig
+++ b/templates/service/new_service.html.twig
@@ -92,106 +92,152 @@
         <h1 class="text-3xl font-bold mb-6 text-gray-800">Crear Nuevo Servicio</h1>
 
         <div class="bg-white shadow-md rounded-lg p-6 mb-8">
-            {{ form_start(serviceForm) }}
+            {{ form_start(serviceForm, {'attr': {'class': 'space-y-8'}}) }}
 
-            <div class="space-y-8">
-                {# Row 1 #}
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-                    <div>
-                        {{ form_row(serviceForm.numeration) }}
-                    </div>
-                    <div>
-                        {{ form_row(serviceForm.title) }}
-                    </div>
-                    <div>
-                        {{ form_label(serviceForm.locality, 'Lugar 📍') }}
-                        {{ form_widget(serviceForm.locality) }}
-                        {{ form_errors(serviceForm.locality) }}
-                    </div>
-                </div>
-
-                {# Row 2 #}
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-                    <div>
-                        {{ form_row(serviceForm.startDate) }}
-                    </div>
-                    <div>
-                        {{ form_row(serviceForm.timeAtBase) }}
-                    </div>
-                    <div>
-                        {{ form_row(serviceForm.endDate) }}
-                    </div>
-                </div>
-
-                {# Row 3 #}
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-                    <div>
-                        {{ form_row(serviceForm.registrationLimitDate) }}
-                    </div>
-                    <div>
-                        {{ form_row(serviceForm.type) }}
-                    </div>
-                    <div>
-                        {{ form_row(serviceForm.category) }}
-                    </div>
-                </div>
-
-                {# Row 4 - Recursos #}
+            {# Row 1: Numeración, Título, Lugar #}
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <div>
-                    <h3 class="text-lg font-semibold mb-2 border-b pb-1">Recursos</h3>
-                    <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-6 items-center">
-                        <div>
-                            {{ form_label(serviceForm.afluencia, 'Afluencia 📈') }}
-                            {{ form_widget(serviceForm.afluencia) }}
-                            {{ form_errors(serviceForm.afluencia) }}
+                    {{ form_label(serviceForm.numeration) }}
+                    {{ form_widget(serviceForm.numeration, {'attr': {'class': 'mt-1'}}) }}
+                    {{ form_errors(serviceForm.numeration) }}
+                </div>
+                <div>
+                    {{ form_label(serviceForm.title) }}
+                    {{ form_widget(serviceForm.title, {'attr': {'class': 'mt-1'}}) }}
+                    {{ form_errors(serviceForm.title) }}
+                </div>
+                <div>
+                    {{ form_label(serviceForm.locality, 'Lugar 📍') }}
+                    {{ form_widget(serviceForm.locality, {'attr': {'class': 'mt-1'}}) }}
+                    {{ form_errors(serviceForm.locality) }}
+                </div>
+            </div>
+
+            {# Row 2: Fechas y Horas #}
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
+                <div>
+                    {{ form_label(serviceForm.startDate) }}
+                    {{ form_widget(serviceForm.startDate, {'attr': {'class': 'mt-1'}}) }}
+                    {{ form_errors(serviceForm.startDate) }}
+                </div>
+                <div>
+                    {{ form_label(serviceForm.endDate) }}
+                    {{ form_widget(serviceForm.endDate, {'attr': {'class': 'mt-1'}}) }}
+                    {{ form_errors(serviceForm.endDate) }}
+                </div>
+                <div class="grid grid-cols-2 gap-4">
+                    <div>
+                        {{ form_label(serviceForm.timeAtBase) }}
+                        {{ form_widget(serviceForm.timeAtBase, {'attr': {'class': 'mt-1'}}) }}
+                        {{ form_errors(serviceForm.timeAtBase) }}
+                    </div>
+                    <div>
+                        {{ form_label(serviceForm.departureTime) }}
+                        {{ form_widget(serviceForm.departureTime, {'attr': {'class': 'mt-1'}}) }}
+                        {{ form_errors(serviceForm.departureTime) }}
+                    </div>
+                </div>
+                <div>
+                    {{ form_label(serviceForm.registrationLimitDate) }}
+                    {{ form_widget(serviceForm.registrationLimitDate, {'attr': {'class': 'mt-1'}}) }}
+                    {{ form_errors(serviceForm.registrationLimitDate) }}
+                </div>
+            </div>
+
+            {# Row 3: Tipo y Categoría #}
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                    {{ form_label(serviceForm.type) }}
+                    {{ form_widget(serviceForm.type, {'attr': {'class': 'mt-1'}}) }}
+                    {{ form_errors(serviceForm.type) }}
+                </div>
+                <div>
+                    {{ form_label(serviceForm.category) }}
+                    {{ form_widget(serviceForm.category, {'attr': {'class': 'mt-1'}}) }}
+                    {{ form_errors(serviceForm.category) }}
+                </div>
+            </div>
+
+            {# Row 4 - Recursos #}
+            <div>
+                <h3 class="text-lg font-semibold mb-4 border-b pb-2">Recursos</h3>
+                <div class="space-y-6">
+                    {# Ambulancias #}
+                    <div>
+                        <h4 class="text-md font-semibold mb-2">Ambulancias 🚑</h4>
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                            <div>
+                                {{ form_label(serviceForm.numSvb, 'SVB') }}
+                                {{ form_widget(serviceForm.numSvb, {'attr': {'class': 'mt-1'}}) }}
+                                {{ form_errors(serviceForm.numSvb) }}
+                            </div>
+                            <div>
+                                {{ form_label(serviceForm.numSva, 'SVA') }}
+                                {{ form_widget(serviceForm.numSva, {'attr': {'class': 'mt-1'}}) }}
+                                {{ form_errors(serviceForm.numSva) }}
+                            </div>
+                            <div>
+                                {{ form_label(serviceForm.numSvae, 'SVAE') }}
+                                {{ form_widget(serviceForm.numSvae, {'attr': {'class': 'mt-1'}}) }}
+                                {{ form_errors(serviceForm.numSvae) }}
+                            </div>
                         </div>
-                        <div>
-                            {{ form_label(serviceForm.numSvb, 'Ambulancias SVB 🚑') }}
-                            {{ form_widget(serviceForm.numSvb) }}
-                            {{ form_errors(serviceForm.numSvb) }}
+                    </div>
+
+                    {# Personal Sanitario #}
+                    <div>
+                        <h4 class="text-md font-semibold mb-2">Personal Sanitario 🥼🩺</h4>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div>
+                                {{ form_label(serviceForm.numDoctors, 'Médicos') }}
+                                {{ form_widget(serviceForm.numDoctors, {'attr': {'class': 'mt-1'}}) }}
+                                {{ form_errors(serviceForm.numDoctors) }}
+                            </div>
+                            <div>
+                                {{ form_label(serviceForm.numNurses, 'Enfermería') }}
+                                {{ form_widget(serviceForm.numNurses, {'attr': {'class': 'mt-1'}}) }}
+                                {{ form_errors(serviceForm.numNurses) }}
+                            </div>
                         </div>
-                        <div>
-                            {{ form_label(serviceForm.numSva, 'Ambulancias SVA 🚑') }}
-                            {{ form_widget(serviceForm.numSva) }}
-                            {{ form_errors(serviceForm.numSva) }}
-                        </div>
-                        <div>
-                            {{ form_label(serviceForm.numSvae, 'Ambulancias SVAE 🚑') }}
-                            {{ form_widget(serviceForm.numSvae) }}
-                            {{ form_errors(serviceForm.numSvae) }}
-                        </div>
-                        <div>
-                            {{ form_label(serviceForm.numMedical, 'Médico/Enfermería 🥼🩺') }}
-                            {{ form_widget(serviceForm.numMedical) }}
-                            {{ form_errors(serviceForm.numMedical) }}
-                        </div>
-                        <div class="flex items-center pt-6">
-                            {{ form_widget(serviceForm.hasFieldHospital) }}
-                            {{ form_label(serviceForm.hasFieldHospital, 'Hospital de Campaña 🏥', {'label_attr': {'class': 'ml-2'}}) }}
-                            {{ form_errors(serviceForm.hasFieldHospital) }}
-                        </div>
-                        <div class="flex items-center pt-6">
-                            {{ form_widget(serviceForm.hasProvisions) }}
-                            {{ form_label(serviceForm.hasProvisions, 'Avituallamiento 🥪', {'label_attr': {'class': 'ml-2'}}) }}
-                            {{ form_errors(serviceForm.hasProvisions) }}
+                    </div>
+
+                    {# Otros Recursos #}
+                    <div>
+                        <h4 class="text-md font-semibold mb-2">Otros</h4>
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 items-center">
+                            <div>
+                                {{ form_label(serviceForm.afluencia, 'Afluencia 📈') }}
+                                {{ form_widget(serviceForm.afluencia, {'attr': {'class': 'mt-1'}}) }}
+                                {{ form_errors(serviceForm.afluencia) }}
+                            </div>
+                            <div class="flex items-center pt-6">
+                                {{ form_widget(serviceForm.hasFieldHospital) }}
+                                {{ form_label(serviceForm.hasFieldHospital, 'Hospital de Campaña 🏥', {'label_attr': {'class': 'ml-2'}}) }}
+                                {{ form_errors(serviceForm.hasFieldHospital) }}
+                            </div>
+                            <div class="flex items-center pt-6">
+                                {{ form_widget(serviceForm.hasProvisions) }}
+                                {{ form_label(serviceForm.hasProvisions, 'Avituallamiento 🥪', {'label_attr': {'class': 'ml-2'}}) }}
+                                {{ form_errors(serviceForm.hasProvisions) }}
+                            </div>
                         </div>
                     </div>
                 </div>
+            </div>
 
-                {# Row 5 - Tareas y Descripción #}
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div>
-                        {{ form_label(serviceForm.tasks, 'Tareas 📝') }}
-                        <div id="tasks-editor"></div>
-                        {{ form_widget(serviceForm.tasks, {'id': 'tasks_textarea', 'attr': {'style': 'display:none;'}}) }}
-                        {{ form_errors(serviceForm.tasks) }}
-                    </div>
-                    <div>
-                        {{ form_label(serviceForm.description, 'Descripción ℹ️') }}
-                        <div id="quill-editor"></div>
-                        {{ form_widget(serviceForm.description, {'id': 'description_editor', 'attr': {'style': 'display:none;'}}) }}
-                        {{ form_errors(serviceForm.description) }}
-                    </div>
+            {# Row 5 - Tareas y Decisión #}
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                <div>
+                    {{ form_label(serviceForm.tasks, 'Tareas 📝') }}
+                    <div id="tasks-editor" class="mt-1"></div>
+                    {{ form_widget(serviceForm.tasks, {'id': 'tasks_textarea', 'attr': {'style': 'display:none;'}}) }}
+                    {{ form_errors(serviceForm.tasks) }}
+                </div>
+                <div>
+                    {{ form_label(serviceForm.description, 'Decisión ℹ️') }}
+                    <div id="quill-editor" class="mt-1"></div>
+                    {{ form_widget(serviceForm.description, {'id': 'description_editor', 'attr': {'style': 'display:none;'}}) }}
+                    {{ form_errors(serviceForm.description) }}
                 </div>
             </div>
 
@@ -200,6 +246,7 @@
             </div>
 
             {{ form_rest(serviceForm) }}
+
 
             <div class="flex items-center justify-end mt-6">
                 <a href="{{ path('app_services_list') }}" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg transition-colors">


### PR DESCRIPTION
This commit refactors the "Create New Service" form to improve its layout and functionality based on user feedback.

The key changes include:
- Rearranging form fields to have labels appear above their corresponding input fields for better readability.
- Positioning the "Hora de Salida" (Departure Time) field next to the "Hora en Base" (Base Time) field.
- Grouping the ambulance type fields (SVB, SVA, SVAE) under a single "Ambulancias" heading.
- Splitting the "Médico/Enfermería" field into two separate fields: "Médicos" and "Enfermería".
- Changing the label of the "Descripción" field to "Decisión" to better reflect its purpose.
- Ensuring that the "Tareas" and "Decisión" text areas retain their rich text editing capabilities.

These changes were implemented by updating the `Service` entity, the `ServiceType` form, the database schema through a migration, and the `new_service.html.twig` template.