### PR TITLE
feat: Implement WhatsApp sharing for services

### DIFF
--- a/src/Service/WhatsAppMessageGenerator.php
+++ b/src/Service/WhatsAppMessageGenerator.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Service;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class WhatsAppMessageGenerator
+{
+    private TranslatorInterface $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function createMessage(Service $service): string
+    {
+        $message = [];
+
+        // Helper for date formatting
+        $dateFormatter = new \IntlDateFormatter(
+            'es_ES',
+            \IntlDateFormatter::FULL,
+            \IntlDateFormatter::NONE,
+            null,
+            null,
+            'EEEE d \'de\' MMMM'
+        );
+
+        // Header
+        $message[] = "*" . $dateFormatter->format($service->getStartDate()) . "*";
+        $message[] = "*" . $service->getTitle() . "*";
+        $message[] = ""; // Newline
+
+        // Timings
+        if ($service->getTimeAtBase()) {
+            $message[] = "H. Base: " . $service->getTimeAtBase()->format('H:i');
+        }
+        if ($service->getDepartureTime()) {
+            $message[] = "Hora de Salida: " . $service->getDepartureTime()->format('H:i');
+        }
+        if ($service->getEndDate()) {
+            $message[] = "Fecha y Hora de Fin: " . $service->getEndDate()->format('d/m/Y H:i');
+        }
+        $message[] = ""; // Newline
+
+        // Location
+        if ($service->getLocality()) {
+            $message[] = "Lugar: " . $service->getLocality();
+            $message[] = ""; // Newline
+        }
+
+        // Conditional resources
+        $resources = [];
+        if ($service->isHasProvisions()) {
+            $resources[] = "Avituallamiento";
+        }
+
+        $ambulances = [];
+        if ($service->getNumSvb() > 0) {
+            $ambulances[] = "SVB (" . $service->getNumSvb() . ")";
+        }
+        if ($service->getNumSva() > 0) {
+            $ambulances[] = "SVA (" . $service->getNumSva() . ")";
+        }
+        if ($service->getNumSvae() > 0) {
+            $ambulances[] = "SVAE (" . $service->getNumSvae() . ")";
+        }
+        if (!empty($ambulances)) {
+            $resources[] = "Ambulancias: " . implode(', ', $ambulances);
+        }
+
+        $medicalStaff = [];
+        if ($service->getNumDoctors() > 0) {
+            $medicalStaff[] = "Médicos (" . $service->getNumDoctors() . ")";
+        }
+        if ($service->getNumNurses() > 0) {
+            $medicalStaff[] = "Enfermería (" . $service->getNumNurses() . ")";
+        }
+        if (!empty($medicalStaff)) {
+            $resources[] = "Personal Sanitario: " . implode(', ', $medicalStaff);
+        }
+
+        if ($service->getAfluencia()) {
+            $resources[] = "Afluencia: " . ucfirst($service->getAfluencia());
+        }
+
+        if ($service->isHasFieldHospital()) {
+            $resources[] = "Hospital de Campaña";
+        }
+
+        if (!empty($resources)) {
+            $message[] = implode("\n", $resources);
+            $message[] = ""; // Newline
+        }
+
+        // Tasks
+        if ($service->getTasks()) {
+            $message[] = "*Tareas:*";
+            $message[] = strip_tags($service->getTasks());
+            $message[] = ""; // Newline
+        }
+
+        // Decision
+        if ($service->getDescription()) {
+            $message[] = "*Decisión:*";
+            $message[] = strip_tags($service->getDescription());
+        }
+
+        return implode("\n", $message);
+    }
+}

--- a/templates/service/view.html.twig
+++ b/templates/service/view.html.twig
@@ -1,50 +1,64 @@
 {% extends 'layout/app.html.twig' %}
 
-{% block title %}Detalles del Servicio{% endblock %}
+{% block title %}Detalles del Servicio: {{ service.title }}{% endblock %}
 
 {% block content %}
-<div class="p-6">
-    <div class="bg-white p-6 rounded-lg shadow-md">
-        <h2 class="text-xl font-bold mb-4 border-b pb-2">Resumen del Servicio para WhatsApp</h2>
+<div class="container mx-auto px-4 py-8">
 
-        <div class="whitespace-pre-wrap font-mono text-sm bg-gray-50 p-4 rounded-md">
-            <strong>{{ service.startDate|format_datetime(locale='es', pattern='EEEE d ''de'' MMMM')|capitalize }}</strong>
-            <strong>{{ service.title }}</strong>
+    {# Flash Messages #}
+    {% for label, messages in app.flashes %}
+        {% for message in messages %}
+            <div class="bg-{{ label == 'success' ? 'green' : 'blue' }}-100 border-l-4 border-{{ label == 'success' ? 'green' : 'blue' }}-500 text-{{ label == 'success' ? 'green' : 'blue' }}-700 p-4 mb-6" role="alert">
+                <p class="font-bold">{{ label == 'success' ? 'Éxito' : 'Información' }}</p>
+                <p>{{ message }}</p>
+            </div>
+        {% endfor %}
+    {% endfor %}
 
-            H. Base: {{ service.timeAtBase ? service.timeAtBase|date('H:i') : 'N/A' }}
-            H. Salida: {{ service.departureTime ? service.departureTime|date('H:i') : 'N/A' }}
-            Fin: {{ service.endDate ? service.endDate|date('H:i') : 'N/A' }} aprox
-
-            Descripción:
-            {{ service.description|raw }}
-
-            {% if service.hasProvisions %}
-            Avituallamiento: Sí
-            {% endif %}
-
-            {% if service.afluencia %}
-            Afluencia: {{ service.afluencia|capitalize }} {% if service.afluencia == 'alta' %}🔴{% endif %}
-            {% endif %}
-
-            {% if service.numSvb > 0 or service.numSva > 0 or service.numSvae > 0 %}
-            Ambulancias:
-                {% if service.numSvb > 0 %}> {{ service.numSvb }} SVB 🚑{% endif %}
-                {% if service.numSva > 0 %}> {{ service.numSva }} SVA 🚑{% endif %}
-                {% if service.numSvae > 0 %}> {{ service.numSvae }} SVAE 🚑{% endif %}
-            {% endif %}
-
-            {% if service.numMedical > 0 %}
-            Médico y enfermería: {{ service.numMedical }} 🥼🩺
-            {% endif %}
-
-            {% if service.hasFieldHospital %}
-            Hospital de campaña: Sí 🏥
-            {% endif %}
+    <div class="bg-white shadow-md rounded-lg p-6">
+        <div class="flex justify-between items-center border-b pb-4 mb-6">
+            <h1 class="text-3xl font-bold text-gray-800">{{ service.title }}</h1>
+            <a href="{{ path('app_services_list') }}" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg transition-colors">
+                &larr; Volver a la Lista
+            </a>
         </div>
 
-        <div class="mt-6 text-center">
-            <a href="{{ whatsapp_url }}" target="_blank" class="inline-block bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded-lg">
-                <i data-lucide="send" class="inline-block w-4 h-4 mr-2"></i>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+            <div>
+                <h3 class="text-lg font-semibold text-gray-700">Detalles</h3>
+                <p><strong>Lugar:</strong> {{ service.locality }}</p>
+                <p><strong>Inicio:</strong> {{ service.startDate|date('d/m/Y H:i') }}</p>
+                <p><strong>Fin:</strong> {{ service.endDate|date('d/m/Y H:i') }}</p>
+                <p><strong>Hora en Base:</strong> {{ service.timeAtBase|date('H:i') }}</p>
+                <p><strong>Hora de Salida:</strong> {{ service.departureTime|date('H:i') }}</p>
+            </div>
+            <div>
+                <h3 class="text-lg font-semibold text-gray-700">Recursos</h3>
+                <p><strong>Ambulancias:</strong> {{ service.numSvb|default(0) }} SVB, {{ service.numSva|default(0) }} SVA, {{ service.numSvae|default(0) }} SVAE</p>
+                <p><strong>Personal:</strong> {{ service.numDoctors|default(0) }} Médicos, {{ service.numNurses|default(0) }} Enfermeros</p>
+                <p><strong>Afluencia:</strong> {{ service.afluencia|capitalize }}</p>
+                <p><strong>Hospital de Campaña:</strong> {{ service.hasFieldHospital ? 'Sí' : 'No' }}</p>
+                <p><strong>Avituallamiento:</strong> {{ service.hasProvisions ? 'Sí' : 'No' }}</p>
+            </div>
+        </div>
+
+        <div class="mb-6">
+            <h3 class="text-lg font-semibold text-gray-700">Tareas</h3>
+            <div class="prose max-w-none bg-gray-50 p-4 rounded-md mt-2">
+                {{ service.tasks|raw }}
+            </div>
+        </div>
+
+        <div class="mb-6">
+            <h3 class="text-lg font-semibold text-gray-700">Decisión</h3>
+            <div class="prose max-w-none bg-gray-50 p-4 rounded-md mt-2">
+                {{ service.description|raw }}
+            </div>
+        </div>
+
+        <div class="mt-8 pt-6 border-t text-center">
+            <a href="{{ whatsappLink }}" target="_blank" class="inline-flex items-center bg-green-500 hover:bg-green-600 text-white font-bold py-3 px-6 rounded-lg text-lg shadow-lg transition-transform transform hover:scale-105">
+                <svg class="w-6 h-6 mr-3" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M.057 24l1.687-6.163c-1.041-1.804-1.588-3.849-1.587-5.946.003-6.556 5.338-11.891 11.893-11.891 3.181.001 6.167 1.24 8.413 3.488 2.245 2.248 3.481 5.236 3.48 8.414-.003 6.557-5.338 11.892-11.894 11.892-1.99-.001-3.951-.5-5.688-1.448l-6.305 1.654zm6.597-3.807c1.676.995 3.276 1.591 5.392 1.592 5.448 0 9.886-4.434 9.889-9.885.002-5.462-4.415-9.89-9.881-9.892-5.452 0-9.887 4.434-9.889 9.886-.001 2.267.651 4.383 1.873 6.223l.225.341-1.251 4.605 4.753-1.241.332.194z"/></svg>
                 Compartir en WhatsApp
             </a>
         </div>


### PR DESCRIPTION
This commit introduces a new feature that allows users to share service details via WhatsApp.

Key changes:
- A `WhatsAppMessageGenerator` service has been created to build a formatted message string from a `Service` entity. This keeps the controller logic clean and follows the single-responsibility principle.
- The `ServiceController` has been refactored to use this new service. The `view` action now generates a `wa.me` link with the pre-filled message.
- After creating a new service, the user is now redirected to the service's view page, where they can immediately see the details and the share button.
- The `view.html.twig` template has been updated to include a prominent "Share on WhatsApp" button, which uses the generated link. The template has also been improved to show a more detailed and user-friendly view of the service information.
- This implementation correctly handles sharing to groups by generating a link without a phone number, allowing the user to select the recipient in WhatsApp.