### PR TITLE
feat: Update new service form layout

### DIFF
--- a/src/Form/ServiceType.php
+++ b/src/Form/ServiceType.php
@@ -14,6 +14,9 @@ use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 
 class ServiceType extends AbstractType
 {
@@ -26,47 +29,47 @@ class ServiceType extends AbstractType
                 'attr' => ['placeholder' => 'Ej: S-2025-001'],
             ])
             ->add('title', TextType::class, [
-                'label' => 'Título del Servicio',
+                'label' => 'Título',
                 'required' => true,
                 'attr' => ['placeholder' => 'Ej: Recogida de Alimentos'],
             ])
             ->add('startDate', DateTimeType::class, [
-                'label' => 'Fecha y Hora de Inicio',
+                'label' => 'Inicio',
                 'widget' => 'single_text',
                 'required' => true,
                 'html5' => true,
             ])
             ->add('endDate', DateTimeType::class, [
-                'label' => 'Fecha y Hora de Fin',
+                'label' => 'Fin',
                 'widget' => 'single_text',
                 'required' => true,
                 'html5' => true,
             ])
             ->add('registrationLimitDate', DateType::class, [
-                'label' => 'Fecha Límite de Inscripción',
+                'label' => 'Límite',
                 'widget' => 'single_text',
                 'required' => true,
                 'html5' => true,
             ])
             ->add('timeAtBase', TimeType::class, [
-                'label' => 'Hora en Base',
+                'label' => 'Base',
                 'widget' => 'single_text',
                 'required' => true,
                 'html5' => true,
             ])
             ->add('departureTime', TimeType::class, [
-                'label' => 'Hora de Salida',
+                'label' => 'Salida',
                 'widget' => 'single_text',
                 'required' => true,
                 'html5' => true,
             ])
             ->add('maxAttendees', IntegerType::class, [
-                'label' => 'Máximo Asistentes',
+                'label' => 'Asistentes',
                 'required' => false,
                 'attr' => ['min' => 1, 'placeholder' => 'Ej: 50'],
             ])
             ->add('type', ChoiceType::class, [
-                'label' => 'Tipo de Servicio',
+                'label' => 'Tipo',
                 'choices' => [
                     'Evento' => 'evento',
                     'Formación' => 'formacion',
@@ -76,7 +79,7 @@ class ServiceType extends AbstractType
                 'required' => true,
             ])
             ->add('category', ChoiceType::class, [
-                'label' => 'Categoría del Servicio',
+                'label' => 'Categoría',
                 'choices' => [
                     'Asistencia Social' => 'asistencia_social',
                     'Medio Ambiente' => 'medio_ambiente',
@@ -87,7 +90,7 @@ class ServiceType extends AbstractType
                 'required' => true,
             ])
             ->add('description', TextareaType::class, [
-                'label' => 'Decisión',
+                'label' => 'Descripción',
                 'required' => false,
             ])
             ->add('recipients', ChoiceType::class, [
@@ -119,24 +122,33 @@ class ServiceType extends AbstractType
                 'required' => false,
             ])
             ->add('numSvb', IntegerType::class, [
-                'label' => 'Ambulancias SVB',
+                'label' => 'SVB',
                 'required' => false,
             ])
             ->add('numSva', IntegerType::class, [
-                'label' => 'Ambulancias SVA',
+                'label' => 'SVA',
                 'required' => false,
             ])
             ->add('numSvae', IntegerType::class, [
-                'label' => 'Ambulancias SVAE',
+                'label' => 'SVAE',
                 'required' => false,
             ])
             ->add('numDoctors', IntegerType::class, [
-                'label' => 'Médicos',
+                'label' => 'Medico',
                 'required' => false,
             ])
-            ->add('numNurses', IntegerType::class, [
-                'label' => 'Enfermeros',
+            ->add('numNurses', HiddenType::class, [
                 'required' => false,
+            ])
+            ->add('numDues', IntegerType::class, [
+                'label' => 'Enfermeros/as (DUE)',
+                'required' => false,
+                'mapped' => false,
+            ])
+            ->add('numTecnicos', IntegerType::class, [
+                'label' => 'Técnicos (TTS)',
+                'required' => false,
+                'mapped' => false,
             ])
             ->add('hasFieldHospital', CheckboxType::class, [
                 'label' => 'Hospital de Campaña',
@@ -150,6 +162,18 @@ class ServiceType extends AbstractType
                 'label' => 'Avituallamiento',
                 'required' => false,
             ]);
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+            $data = $event->getData();
+            $form = $event->getForm();
+
+            $numDues = $data['numDues'] ?? 0;
+            $numTecnicos = $data['numTecnicos'] ?? 0;
+
+            $data['numNurses'] = $numDues + $numTecnicos;
+
+            $event->setData($data);
+        });
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/templates/service/new_service.html.twig
+++ b/templates/service/new_service.html.twig
@@ -94,78 +94,81 @@
         <div class="bg-white shadow-md rounded-lg p-6 mb-8">
             {{ form_start(serviceForm, {'attr': {'class': 'space-y-8'}}) }}
 
-            {# Row 1: Numeración, Título, Lugar #}
+            {# Row 1: Numeración, Título, Lugar (3 columnas) #}
             <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <div>
-                    {{ form_label(serviceForm.numeration) }}
+                    {{ form_label(serviceForm.numeration, 'Numeración') }}
                     {{ form_widget(serviceForm.numeration, {'attr': {'class': 'mt-1'}}) }}
                     {{ form_errors(serviceForm.numeration) }}
                 </div>
                 <div>
-                    {{ form_label(serviceForm.title) }}
+                    {{ form_label(serviceForm.title, 'Título') }}
                     {{ form_widget(serviceForm.title, {'attr': {'class': 'mt-1'}}) }}
                     {{ form_errors(serviceForm.title) }}
                 </div>
                 <div>
-                    {{ form_label(serviceForm.locality, 'Lugar 📍') }}
+                    {{ form_label(serviceForm.locality, 'Lugar') }}
                     {{ form_widget(serviceForm.locality, {'attr': {'class': 'mt-1'}}) }}
                     {{ form_errors(serviceForm.locality) }}
                 </div>
             </div>
 
-            {# Row 2: Fechas y Horas #}
+            {# Row 2: Inicio, Base, Salida, Fin (4 columnas) #}
             <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
                 <div>
-                    {{ form_label(serviceForm.startDate) }}
+                    {{ form_label(serviceForm.startDate, 'Inicio') }}
                     {{ form_widget(serviceForm.startDate, {'attr': {'class': 'mt-1'}}) }}
                     {{ form_errors(serviceForm.startDate) }}
                 </div>
                 <div>
-                    {{ form_label(serviceForm.endDate) }}
+                    {{ form_label(serviceForm.timeAtBase, 'Base') }}
+                    {{ form_widget(serviceForm.timeAtBase, {'attr': {'class': 'mt-1'}}) }}
+                    {{ form_errors(serviceForm.timeAtBase) }}
+                </div>
+                <div>
+                    {{ form_label(serviceForm.departureTime, 'Salida') }}
+                    {{ form_widget(serviceForm.departureTime, {'attr': {'class': 'mt-1'}}) }}
+                    {{ form_errors(serviceForm.departureTime) }}
+                </div>
+                <div>
+                    {{ form_label(serviceForm.endDate, 'Fin') }}
                     {{ form_widget(serviceForm.endDate, {'attr': {'class': 'mt-1'}}) }}
                     {{ form_errors(serviceForm.endDate) }}
                 </div>
-                <div class="grid grid-cols-2 gap-4">
-                    <div>
-                        {{ form_label(serviceForm.timeAtBase) }}
-                        {{ form_widget(serviceForm.timeAtBase, {'attr': {'class': 'mt-1'}}) }}
-                        {{ form_errors(serviceForm.timeAtBase) }}
-                    </div>
-                    <div>
-                        {{ form_label(serviceForm.departureTime) }}
-                        {{ form_widget(serviceForm.departureTime, {'attr': {'class': 'mt-1'}}) }}
-                        {{ form_errors(serviceForm.departureTime) }}
-                    </div>
-                </div>
+            </div>
+
+            {# Row 3: Límite, Asistentes, Tipo, Categoría (4 columnas) #}
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
                 <div>
-                    {{ form_label(serviceForm.registrationLimitDate) }}
+                    {{ form_label(serviceForm.registrationLimitDate, 'Límite') }}
                     {{ form_widget(serviceForm.registrationLimitDate, {'attr': {'class': 'mt-1'}}) }}
                     {{ form_errors(serviceForm.registrationLimitDate) }}
                 </div>
-            </div>
-
-            {# Row 3: Tipo y Categoría #}
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div>
-                    {{ form_label(serviceForm.type) }}
+                    {{ form_label(serviceForm.maxAttendees, 'Asistentes') }}
+                    {{ form_widget(serviceForm.maxAttendees, {'attr': {'class': 'mt-1'}}) }}
+                    {{ form_errors(serviceForm.maxAttendees) }}
+                </div>
+                <div>
+                    {{ form_label(serviceForm.type, 'Tipo') }}
                     {{ form_widget(serviceForm.type, {'attr': {'class': 'mt-1'}}) }}
                     {{ form_errors(serviceForm.type) }}
                 </div>
                 <div>
-                    {{ form_label(serviceForm.category) }}
+                    {{ form_label(serviceForm.category, 'Categoría') }}
                     {{ form_widget(serviceForm.category, {'attr': {'class': 'mt-1'}}) }}
                     {{ form_errors(serviceForm.category) }}
                 </div>
             </div>
 
-            {# Row 4 - Recursos #}
+            {# Recursos #}
             <div>
                 <h3 class="text-lg font-semibold mb-4 border-b pb-2">Recursos</h3>
-                <div class="space-y-6">
-                    {# Ambulancias #}
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                    {# Columna Ambulancia #}
                     <div>
-                        <h4 class="text-md font-semibold mb-2">Ambulancias 🚑</h4>
-                        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                        <h4 class="text-md font-semibold mb-2">Ambulancia 🚑</h4>
+                        <div class="space-y-2">
                             <div>
                                 {{ form_label(serviceForm.numSvb, 'SVB') }}
                                 {{ form_widget(serviceForm.numSvb, {'attr': {'class': 'mt-1'}}) }}
@@ -184,38 +187,46 @@
                         </div>
                     </div>
 
-                    {# Personal Sanitario #}
+                    {# Columna Personal Sanitario #}
                     <div>
                         <h4 class="text-md font-semibold mb-2">Personal Sanitario 🥼🩺</h4>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div class="space-y-2">
                             <div>
-                                {{ form_label(serviceForm.numDoctors, 'Médicos') }}
+                                {{ form_label(serviceForm.numDoctors, 'Medico') }}
                                 {{ form_widget(serviceForm.numDoctors, {'attr': {'class': 'mt-1'}}) }}
                                 {{ form_errors(serviceForm.numDoctors) }}
                             </div>
                             <div>
-                                {{ form_label(serviceForm.numNurses, 'Enfermería') }}
-                                {{ form_widget(serviceForm.numNurses, {'attr': {'class': 'mt-1'}}) }}
-                                {{ form_errors(serviceForm.numNurses) }}
+                                {{ form_label(serviceForm.numDues, 'Enfermeria') }}
+                                <div class="grid grid-cols-2 gap-2">
+                                    <div>
+                                        {{ form_widget(serviceForm.numDues, {'attr': {'placeholder': 'DUE'}}) }}
+                                        {{ form_errors(serviceForm.numDues) }}
+                                    </div>
+                                    <div>
+                                        {{ form_widget(serviceForm.numTecnicos, {'attr': {'placeholder': 'Técnicos'}}) }}
+                                        {{ form_errors(serviceForm.numTecnicos) }}
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
 
-                    {# Otros Recursos #}
+                    {# Columna Otros #}
                     <div>
                         <h4 class="text-md font-semibold mb-2">Otros</h4>
-                        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 items-center">
+                        <div class="space-y-2">
                             <div>
                                 {{ form_label(serviceForm.afluencia, 'Afluencia 📈') }}
                                 {{ form_widget(serviceForm.afluencia, {'attr': {'class': 'mt-1'}}) }}
                                 {{ form_errors(serviceForm.afluencia) }}
                             </div>
-                            <div class="flex items-center pt-6">
+                            <div class="flex items-center pt-2">
                                 {{ form_widget(serviceForm.hasFieldHospital) }}
                                 {{ form_label(serviceForm.hasFieldHospital, 'Hospital de Campaña 🏥', {'label_attr': {'class': 'ml-2'}}) }}
                                 {{ form_errors(serviceForm.hasFieldHospital) }}
                             </div>
-                            <div class="flex items-center pt-6">
+                            <div class="flex items-center pt-2">
                                 {{ form_widget(serviceForm.hasProvisions) }}
                                 {{ form_label(serviceForm.hasProvisions, 'Avituallamiento 🥪', {'label_attr': {'class': 'ml-2'}}) }}
                                 {{ form_errors(serviceForm.hasProvisions) }}
@@ -225,8 +236,8 @@
                 </div>
             </div>
 
-            {# Row 5 - Tareas y Decisión #}
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+            {# Tareas y Descripción #}
+            <div class="space-y-8">
                 <div>
                     {{ form_label(serviceForm.tasks, 'Tareas 📝') }}
                     <div id="tasks-editor" class="mt-1"></div>
@@ -234,7 +245,7 @@
                     {{ form_errors(serviceForm.tasks) }}
                 </div>
                 <div>
-                    {{ form_label(serviceForm.description, 'Decisión ℹ️') }}
+                    {{ form_label(serviceForm.description, 'Descripción ℹ️') }}
                     <div id="quill-editor" class="mt-1"></div>
                     {{ form_widget(serviceForm.description, {'id': 'description_editor', 'attr': {'style': 'display:none;'}}) }}
                     {{ form_errors(serviceForm.description) }}
@@ -243,6 +254,7 @@
 
             <div style="display:none;">
                 {{ form_row(serviceForm.recipients) }}
+                {{ form_row(serviceForm.numNurses) }}
             </div>
 
             {{ form_rest(serviceForm) }}


### PR DESCRIPTION
This commit updates the layout of the "Crear Nuevo Servicio" form to match the new design specifications.

The changes include:
- Rearranging the form fields into a new grid layout.
- Splitting the 'Enfermeria' field into two separate fields: 'DUE' and 'Técnicos'.
- Using a PRE_SUBMIT event listener to calculate the total number of nurses and store it in the 'numNurses' field.