### PR TITLE
feat: Improve service creation page with live preview and editor fix

### DIFF
--- a/templates/service/new_service.html.twig
+++ b/templates/service/new_service.html.twig
@@ -16,6 +16,44 @@
         #quill-editor, #tasks-editor {
             height: 300px;
         }
+        /* WhatsApp Preview Styles */
+        .whatsapp-preview {
+            background-color: #e5ddd5; /* WhatsApp background color */
+            border-radius: 10px;
+            padding: 20px;
+            font-family: 'Helvetica', sans-serif;
+            border: 1px solid #ccc;
+            width: 100%;
+            max-width: 450px; /* Typical phone width */
+            margin: 0 auto;
+        }
+        .whatsapp-message {
+            background-color: #dcf8c6; /* Sent message bubble color */
+            border-radius: 8px;
+            padding: 10px 15px;
+            position: relative;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+            white-space: pre-wrap; /* Preserve whitespace and newlines */
+            word-wrap: break-word;
+        }
+        .whatsapp-message::before {
+            content: '';
+            position: absolute;
+            top: 10px;
+            right: -10px;
+            width: 0;
+            height: 0;
+            border: 10px solid transparent;
+            border-left-color: #dcf8c6;
+            border-right: 0;
+            border-top: 0;
+        }
+        .whatsapp-preview h3 {
+            text-align: center;
+            color: #075e54; /* WhatsApp dark green */
+            margin-bottom: 15px;
+            font-weight: bold;
+        }
     </style>
 {% endblock %}
 
@@ -43,9 +81,20 @@
             const editorContainer = document.querySelector(containerId);
             const hiddenTextarea = document.querySelector(textareaId);
 
-            if (!editorContainer || !hiddenTextarea || quillInstances[containerId]) {
+            if (!editorContainer || !hiddenTextarea) return;
+
+            // If an instance already exists, destroy it before creating a new one
+            if (quillInstances[containerId]) {
+                 // It's often better to let turbo:before-cache handle cleanup,
+                 // but this is an extra safeguard.
+                delete quillInstances[containerId];
+            }
+             if (editorContainer.querySelector('.ql-editor')) {
+                // Already initialized, perhaps by a previous script run that wasn't cleaned up.
+                // It's better to avoid re-initializing.
                 return;
             }
+
 
             const toolbarOptions = [
                 [{ 'header': [1, 2, 3, false] }],
@@ -64,212 +113,293 @@
 
             quill.on('text-change', function() {
                 hiddenTextarea.value = quill.root.innerHTML;
+                updateWhatsAppPreview(); // Update preview on text change
             });
+
+             // Set initial content from textarea
+            if (hiddenTextarea.value) {
+                quill.root.innerHTML = hiddenTextarea.value;
+            }
 
             quillInstances[containerId] = quill;
         }
 
         function initializeAllQuillEditors() {
-            setupQuill('#quill-editor', '#description_editor');
-            setupQuill('#tasks-editor', '#tasks_textarea');
+            setupQuill('#quill-editor', '#service_description');
+            setupQuill('#tasks-editor', '#service_tasks');
+            updateWhatsAppPreview(); // Initial preview generation
         }
 
-        document.addEventListener('turbo:before-cache', function() {
+        function cleanupQuillInstances() {
             for (const key in quillInstances) {
                 if (quillInstances.hasOwnProperty(key)) {
-                    quillInstances[key] = null;
+                    const container = document.querySelector(key);
+                    if (container) {
+                        const editor = container.querySelector('.ql-editor');
+                        if (editor) {
+                           // container.innerHTML = ''; // Clear the container
+                        }
+                    }
+                    delete quillInstances[key];
                 }
             }
-        }, { once: true });
+        }
 
+        async function updateWhatsAppPreview() {
+            const form = document.querySelector('form[name="service"]');
+            if (!form) return;
+
+            const formData = new FormData(form);
+            const data = Object.fromEntries(formData.entries());
+
+            // Manually get content from Quill editors
+            data.description = quillInstances['#quill-editor'] ? quillInstances['#quill-editor'].root.innerHTML : '';
+            data.tasks = quillInstances['#tasks-editor'] ? quillInstances['#tasks-editor'].root.innerHTML : '';
+
+            try {
+                const response = await fetch('{{ path('app_service_preview') }}', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Requested-With': 'XMLHttpRequest'
+                    },
+                    body: JSON.stringify(data)
+                });
+                const result = await response.json();
+                const previewElement = document.getElementById('whatsapp-message-content');
+                if (previewElement) {
+                    previewElement.textContent = result.message || 'Error al generar la vista previa.';
+                }
+            } catch (error) {
+                console.error('Error updating WhatsApp preview:', error);
+                const previewElement = document.getElementById('whatsapp-message-content');
+                if (previewElement) {
+                    previewElement.textContent = 'Error de conexión al generar la vista previa.';
+                }
+            }
+        }
+
+
+        // Turbo event listeners
+        document.addEventListener('turbo:before-cache', cleanupQuillInstances);
         document.addEventListener('turbo:load', initializeAllQuillEditors);
-        document.addEventListener('DOMContentLoaded', initializeAllQuillEditors);
+
+        // Fallback for non-turbo visits
+        if (typeof Turbo === 'undefined') {
+            document.addEventListener('DOMContentLoaded', initializeAllQuillEditors);
+        }
+
+        // Add event listeners to form inputs to update preview
+        document.addEventListener('turbo:load', () => {
+             const form = document.querySelector('form[name="service"]');
+             if(form) {
+                form.addEventListener('input', updateWhatsAppPreview);
+             }
+        });
+
+
     </script>
 {% endblock %}
 
 {% block content %}
     <div class="container mx-auto px-4 py-8">
-        <h1 class="text-3xl font-bold mb-6 text-gray-800">Crear Nuevo Servicio</h1>
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+            {# Form Column #}
+            <div class="lg:col-span-2">
+                <h1 class="text-3xl font-bold mb-6 text-gray-800">Crear Nuevo Servicio</h1>
+                <div class="bg-white shadow-md rounded-lg p-6">
+                    {{ form_start(serviceForm, {'attr': {'class': 'space-y-8', 'name': 'service'}}) }}
 
-        <div class="bg-white shadow-md rounded-lg p-6 mb-8">
-            {{ form_start(serviceForm, {'attr': {'class': 'space-y-8'}}) }}
-
-            {# Row 1: Numeración, Título, Lugar (3 columnas) #}
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <div>
-                    {{ form_label(serviceForm.numeration, 'Numeración') }}
-                    {{ form_widget(serviceForm.numeration, {'attr': {'class': 'mt-1'}}) }}
-                    {{ form_errors(serviceForm.numeration) }}
-                </div>
-                <div>
-                    {{ form_label(serviceForm.title, 'Título') }}
-                    {{ form_widget(serviceForm.title, {'attr': {'class': 'mt-1'}}) }}
-                    {{ form_errors(serviceForm.title) }}
-                </div>
-                <div>
-                    {{ form_label(serviceForm.locality, 'Lugar') }}
-                    {{ form_widget(serviceForm.locality, {'attr': {'class': 'mt-1'}}) }}
-                    {{ form_errors(serviceForm.locality) }}
-                </div>
-            </div>
-
-            {# Row 2: Inicio, Base, Salida, Fin (4 columnas) #}
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
-                <div>
-                    {{ form_label(serviceForm.startDate, 'Inicio') }}
-                    {{ form_widget(serviceForm.startDate, {'attr': {'class': 'mt-1'}}) }}
-                    {{ form_errors(serviceForm.startDate) }}
-                </div>
-                <div>
-                    {{ form_label(serviceForm.timeAtBase, 'Base') }}
-                    {{ form_widget(serviceForm.timeAtBase, {'attr': {'class': 'mt-1'}}) }}
-                    {{ form_errors(serviceForm.timeAtBase) }}
-                </div>
-                <div>
-                    {{ form_label(serviceForm.departureTime, 'Salida') }}
-                    {{ form_widget(serviceForm.departureTime, {'attr': {'class': 'mt-1'}}) }}
-                    {{ form_errors(serviceForm.departureTime) }}
-                </div>
-                <div>
-                    {{ form_label(serviceForm.endDate, 'Fin') }}
-                    {{ form_widget(serviceForm.endDate, {'attr': {'class': 'mt-1'}}) }}
-                    {{ form_errors(serviceForm.endDate) }}
-                </div>
-            </div>
-
-            {# Row 3: Límite, Asistentes, Tipo, Categoría (4 columnas) #}
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
-                <div>
-                    {{ form_label(serviceForm.registrationLimitDate, 'Límite') }}
-                    {{ form_widget(serviceForm.registrationLimitDate, {'attr': {'class': 'mt-1'}}) }}
-                    {{ form_errors(serviceForm.registrationLimitDate) }}
-                </div>
-                <div>
-                    {{ form_label(serviceForm.maxAttendees, 'Asistentes') }}
-                    {{ form_widget(serviceForm.maxAttendees, {'attr': {'class': 'mt-1'}}) }}
-                    {{ form_errors(serviceForm.maxAttendees) }}
-                </div>
-                <div>
-                    {{ form_label(serviceForm.type, 'Tipo') }}
-                    {{ form_widget(serviceForm.type, {'attr': {'class': 'mt-1'}}) }}
-                    {{ form_errors(serviceForm.type) }}
-                </div>
-                <div>
-                    {{ form_label(serviceForm.category, 'Categoría') }}
-                    {{ form_widget(serviceForm.category, {'attr': {'class': 'mt-1'}}) }}
-                    {{ form_errors(serviceForm.category) }}
-                </div>
-            </div>
-
-            {# Recursos #}
-            <div>
-                <h3 class="text-lg font-semibold mb-4 border-b pb-2">Recursos</h3>
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-                    {# Columna Ambulancia #}
-                    <div>
-                        <h4 class="text-md font-semibold mb-2">Ambulancia 🚑</h4>
-                        <div class="space-y-2">
-                            <div>
-                                {{ form_label(serviceForm.numSvb, 'SVB') }}
-                                {{ form_widget(serviceForm.numSvb, {'attr': {'class': 'mt-1'}}) }}
-                                {{ form_errors(serviceForm.numSvb) }}
-                            </div>
-                            <div>
-                                {{ form_label(serviceForm.numSva, 'SVA') }}
-                                {{ form_widget(serviceForm.numSva, {'attr': {'class': 'mt-1'}}) }}
-                                {{ form_errors(serviceForm.numSva) }}
-                            </div>
-                            <div>
-                                {{ form_label(serviceForm.numSvae, 'SVAE') }}
-                                {{ form_widget(serviceForm.numSvae, {'attr': {'class': 'mt-1'}}) }}
-                                {{ form_errors(serviceForm.numSvae) }}
-                            </div>
+                    {# Row 1: Numeración, Título, Lugar (3 columnas) #}
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                        <div>
+                            {{ form_label(serviceForm.numeration, 'Numeración') }}
+                            {{ form_widget(serviceForm.numeration, {'attr': {'class': 'mt-1'}}) }}
+                            {{ form_errors(serviceForm.numeration) }}
+                        </div>
+                        <div>
+                            {{ form_label(serviceForm.title, 'Título') }}
+                            {{ form_widget(serviceForm.title, {'attr': {'class': 'mt-1'}}) }}
+                            {{ form_errors(serviceForm.title) }}
+                        </div>
+                        <div>
+                            {{ form_label(serviceForm.locality, 'Lugar') }}
+                            {{ form_widget(serviceForm.locality, {'attr': {'class': 'mt-1'}}) }}
+                            {{ form_errors(serviceForm.locality) }}
                         </div>
                     </div>
 
-                    {# Columna Personal Sanitario #}
+                    {# Row 2: Inicio, Base, Salida, Fin (4 columnas) #}
+                    <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
+                        <div>
+                            {{ form_label(serviceForm.startDate, 'Inicio') }}
+                            {{ form_widget(serviceForm.startDate, {'attr': {'class': 'mt-1'}}) }}
+                            {{ form_errors(serviceForm.startDate) }}
+                        </div>
+                        <div>
+                            {{ form_label(serviceForm.timeAtBase, 'Base') }}
+                            {{ form_widget(serviceForm.timeAtBase, {'attr': {'class': 'mt-1'}}) }}
+                            {{ form_errors(serviceForm.timeAtBase) }}
+                        </div>
+                        <div>
+                            {{ form_label(serviceForm.departureTime, 'Salida') }}
+                            {{ form_widget(serviceForm.departureTime, {'attr': {'class': 'mt-1'}}) }}
+                            {{ form_errors(serviceForm.departureTime) }}
+                        </div>
+                        <div>
+                            {{ form_label(serviceForm.endDate, 'Fin') }}
+                            {{ form_widget(serviceForm.endDate, {'attr': {'class': 'mt-1'}}) }}
+                            {{ form_errors(serviceForm.endDate) }}
+                        </div>
+                    </div>
+
+                    {# Row 3: Límite, Asistentes, Tipo, Categoría (4 columnas) #}
+                    <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
+                        <div>
+                            {{ form_label(serviceForm.registrationLimitDate, 'Límite') }}
+                            {{ form_widget(serviceForm.registrationLimitDate, {'attr': {'class': 'mt-1'}}) }}
+                            {{ form_errors(serviceForm.registrationLimitDate) }}
+                        </div>
+                        <div>
+                            {{ form_label(serviceForm.maxAttendees, 'Asistentes') }}
+                            {{ form_widget(serviceForm.maxAttendees, {'attr': {'class': 'mt-1'}}) }}
+                            {{ form_errors(serviceForm.maxAttendees) }}
+                        </div>
+                        <div>
+                            {{ form_label(serviceForm.type, 'Tipo') }}
+                            {{ form_widget(serviceForm.type, {'attr': {'class': 'mt-1'}}) }}
+                            {{ form_errors(serviceForm.type) }}
+                        </div>
+                        <div>
+                            {{ form_label(serviceForm.category, 'Categoría') }}
+                            {{ form_widget(serviceForm.category, {'attr': {'class': 'mt-1'}}) }}
+                            {{ form_errors(serviceForm.category) }}
+                        </div>
+                    </div>
+
+                    {# Recursos #}
                     <div>
-                        <h4 class="text-md font-semibold mb-2">Personal Sanitario 🥼🩺</h4>
-                        <div class="space-y-2">
+                        <h3 class="text-lg font-semibold mb-4 border-b pb-2">Recursos</h3>
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                            {# Columna Ambulancia #}
                             <div>
-                                {{ form_label(serviceForm.numDoctors, 'Medico') }}
-                                {{ form_widget(serviceForm.numDoctors, {'attr': {'class': 'mt-1'}}) }}
-                                {{ form_errors(serviceForm.numDoctors) }}
-                            </div>
-                            <div>
-                                {{ form_label(serviceForm.numDues, 'Enfermeria') }}
-                                <div class="grid grid-cols-2 gap-2">
+                                <h4 class="text-md font-semibold mb-2">Ambulancia 🚑</h4>
+                                <div class="space-y-2">
                                     <div>
-                                        {{ form_widget(serviceForm.numDues, {'attr': {'placeholder': 'DUE'}}) }}
-                                        {{ form_errors(serviceForm.numDues) }}
+                                        {{ form_label(serviceForm.numSvb, 'SVB') }}
+                                        {{ form_widget(serviceForm.numSvb, {'attr': {'class': 'mt-1'}}) }}
+                                        {{ form_errors(serviceForm.numSvb) }}
                                     </div>
                                     <div>
-                                        {{ form_widget(serviceForm.numTecnicos, {'attr': {'placeholder': 'Técnicos'}}) }}
-                                        {{ form_errors(serviceForm.numTecnicos) }}
+                                        {{ form_label(serviceForm.numSva, 'SVA') }}
+                                        {{ form_widget(serviceForm.numSva, {'attr': {'class': 'mt-1'}}) }}
+                                        {{ form_errors(serviceForm.numSva) }}
+                                    </div>
+                                    <div>
+                                        {{ form_label(serviceForm.numSvae, 'SVAE') }}
+                                        {{ form_widget(serviceForm.numSvae, {'attr': {'class': 'mt-1'}}) }}
+                                        {{ form_errors(serviceForm.numSvae) }}
+                                    </div>
+                                </div>
+                            </div>
+
+                            {# Columna Personal Sanitario #}
+                            <div>
+                                <h4 class="text-md font-semibold mb-2">Personal Sanitario 🥼🩺</h4>
+                                <div class="space-y-2">
+                                    <div>
+                                        {{ form_label(serviceForm.numDoctors, 'Medico') }}
+                                        {{ form_widget(serviceForm.numDoctors, {'attr': {'class': 'mt-1'}}) }}
+                                        {{ form_errors(serviceForm.numDoctors) }}
+                                    </div>
+                                    <div>
+                                        {{ form_label(serviceForm.numDues, 'Enfermeria') }}
+                                        <div class="grid grid-cols-2 gap-2">
+                                            <div>
+                                                {{ form_widget(serviceForm.numDues, {'attr': {'placeholder': 'DUE'}}) }}
+                                                {{ form_errors(serviceForm.numDues) }}
+                                            </div>
+                                            <div>
+                                                {{ form_widget(serviceForm.numTecnicos, {'attr': {'placeholder': 'Técnicos'}}) }}
+                                                {{ form_errors(serviceForm.numTecnicos) }}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            {# Columna Otros #}
+                            <div>
+                                <h4 class="text-md font-semibold mb-2">Otros</h4>
+                                <div class="space-y-2">
+                                    <div>
+                                        {{ form_label(serviceForm.afluencia, 'Afluencia 📈') }}
+                                        {{ form_widget(serviceForm.afluencia, {'attr': {'class': 'mt-1'}}) }}
+                                        {{ form_errors(serviceForm.afluencia) }}
+                                    </div>
+                                    <div class="flex items-center pt-2">
+                                        {{ form_widget(serviceForm.hasFieldHospital) }}
+                                        {{ form_label(serviceForm.hasFieldHospital, 'Hospital de Campaña 🏥', {'label_attr': {'class': 'ml-2'}}) }}
+                                        {{ form_errors(serviceForm.hasFieldHospital) }}
+                                    </div>
+                                    <div class="flex items-center pt-2">
+                                        {{ form_widget(serviceForm.hasProvisions) }}
+                                        {{ form_label(serviceForm.hasProvisions, 'Avituallamiento 🥪', {'label_attr': {'class': 'ml-2'}}) }}
+                                        {{ form_errors(serviceForm.hasProvisions) }}
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
 
-                    {# Columna Otros #}
-                    <div>
-                        <h4 class="text-md font-semibold mb-2">Otros</h4>
-                        <div class="space-y-2">
-                            <div>
-                                {{ form_label(serviceForm.afluencia, 'Afluencia 📈') }}
-                                {{ form_widget(serviceForm.afluencia, {'attr': {'class': 'mt-1'}}) }}
-                                {{ form_errors(serviceForm.afluencia) }}
-                            </div>
-                            <div class="flex items-center pt-2">
-                                {{ form_widget(serviceForm.hasFieldHospital) }}
-                                {{ form_label(serviceForm.hasFieldHospital, 'Hospital de Campaña 🏥', {'label_attr': {'class': 'ml-2'}}) }}
-                                {{ form_errors(serviceForm.hasFieldHospital) }}
-                            </div>
-                            <div class="flex items-center pt-2">
-                                {{ form_widget(serviceForm.hasProvisions) }}
-                                {{ form_label(serviceForm.hasProvisions, 'Avituallamiento 🥪', {'label_attr': {'class': 'ml-2'}}) }}
-                                {{ form_errors(serviceForm.hasProvisions) }}
-                            </div>
+                    {# Tareas y Descripción #}
+                    <div class="space-y-8">
+                        <div>
+                            {{ form_label(serviceForm.tasks, 'Tareas 📝') }}
+                            <div id="tasks-editor" class="mt-1"></div>
+                            {{ form_widget(serviceForm.tasks, {'id': 'service_tasks', 'attr': {'style': 'display:none;'}}) }}
+                            {{ form_errors(serviceForm.tasks) }}
+                        </div>
+                        <div>
+                            {{ form_label(serviceForm.description, 'Descripción ℹ️') }}
+                            <div id="quill-editor" class="mt-1"></div>
+                            {{ form_widget(serviceForm.description, {'id': 'service_description', 'attr': {'style': 'display:none;'}}) }}
+                            {{ form_errors(serviceForm.description) }}
+                        </div>
+                    </div>
+
+                    <div style="display:none;">
+                        {{ form_row(serviceForm.recipients) }}
+                        {{ form_row(serviceForm.numNurses) }}
+                    </div>
+
+                    {{ form_rest(serviceForm) }}
+
+
+                    <div class="flex items-center justify-end mt-6">
+                        <a href="{{ path('app_services_list') }}" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg transition-colors">
+                            Volver a la Lista
+                        </a>
+                        <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors ml-3">
+                            Guardar y Continuar
+                        </button>
+                    </div>
+
+                    {{ form_end(serviceForm) }}
+                </div>
+            </div>
+
+            {# WhatsApp Preview Column #}
+            <div class="lg:col-span-1">
+                <div class="sticky top-8">
+                    <div class="whatsapp-preview">
+                        <h3>Vista Previa de WhatsApp</h3>
+                        <div class="whatsapp-message" id="whatsapp-message-content">
+                            Rellena el formulario para ver el mensaje...
                         </div>
                     </div>
                 </div>
             </div>
-
-            {# Tareas y Descripción #}
-            <div class="space-y-8">
-                <div>
-                    {{ form_label(serviceForm.tasks, 'Tareas 📝') }}
-                    <div id="tasks-editor" class="mt-1"></div>
-                    {{ form_widget(serviceForm.tasks, {'id': 'tasks_textarea', 'attr': {'style': 'display:none;'}}) }}
-                    {{ form_errors(serviceForm.tasks) }}
-                </div>
-                <div>
-                    {{ form_label(serviceForm.description, 'Descripción ℹ️') }}
-                    <div id="quill-editor" class="mt-1"></div>
-                    {{ form_widget(serviceForm.description, {'id': 'description_editor', 'attr': {'style': 'display:none;'}}) }}
-                    {{ form_errors(serviceForm.description) }}
-                </div>
-            </div>
-
-            <div style="display:none;">
-                {{ form_row(serviceForm.recipients) }}
-                {{ form_row(serviceForm.numNurses) }}
-            </div>
-
-            {{ form_rest(serviceForm) }}
-
-
-            <div class="flex items-center justify-end mt-6">
-                <a href="{{ path('app_services_list') }}" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg transition-colors">
-                    Volver a la Lista
-                </a>
-                <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors ml-3">
-                    Guardar Servicio
-                </button>
-            </div>
-
-            {{ form_end(serviceForm) }}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
This commit introduces several improvements to the "New Service" creation page:

1.  **Fixes Quill Editor Initialization:** The rich text editor for the "Tasks" and "Description" fields now initializes correctly without requiring a page refresh. This is achieved by refining the JavaScript event listeners to work reliably with Turbo.

2.  **Adds Live WhatsApp Preview:** A new section has been added to the page to display a real-time preview of the WhatsApp message. This preview updates as the user fills out the form. A new API endpoint (`/service/preview`) was created to support this feature.

3.  **Enhances WhatsApp Message:** The generated WhatsApp message now includes "Asisto" and "No Asisto" links, allowing users to confirm their attendance directly from the message. These are formatted as clean hyperlinks, and emojis are used for better visual identification.

4.  **Updates Button Text:** The "Guardar Servicio" button has been renamed to "Guardar y Continuar" to better reflect the workflow.