### PR TITLE
Fix: Prevent double rendering of whatsappMessage field

### DIFF
--- a/templates/service/new_service.html.twig
+++ b/templates/service/new_service.html.twig
@@ -430,14 +430,10 @@
                     <div style="display:none;">
                         {{ form_row(serviceForm.recipients) }}
                         {{ form_row(serviceForm.numNurses) }}
+                        {{ form_row(serviceForm.whatsappMessage) }}
                     </div>
 
                     {{ form_rest(serviceForm) }}
-
-
-                    <div style="display:none;">
-                        {{ form_row(serviceForm.whatsappMessage) }}
-                    </div>
 
                     <div class="flex items-center justify-end mt-6">
                         <a href="{{ path('app_services_list') }}" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg transition-colors">


### PR DESCRIPTION
In the `new_service.html.twig` template, the `whatsappMessage` form field was being rendered by `form_rest()` and then again explicitly. This caused a `BadMethodCallException`.

This change moves the explicit rendering of `whatsappMessage` to before the `form_rest()` call, ensuring the field is only rendered once.