### PR TITLE
Refactor new service creation workflow

### DIFF
--- a/src/Service/WhatsAppMessageGenerator.php
+++ b/src/Service/WhatsAppMessageGenerator.php
@@ -120,8 +120,8 @@ class WhatsAppMessageGenerator
             $unattendUrl = $this->urlGenerator->generate('app_service_unattend', ['id' => $service->getId()], UrlGeneratorInterface::ABSOLUTE_URL);
 
             $message[] = "Por favor, confirma tu asistencia pulsando en uno de los siguientes enlaces:";
-            $message[] = "✅ *Asisto*: " . $attendUrl;
-            $message[] = "❌ *No Asisto*: " . $unattendUrl;
+            $message[] = "✅ *Asisto* " . $attendUrl;
+            $message[] = "❌ *No Asisto* " . $unattendUrl;
         } else {
             // Placeholder for the preview on the new service page
             $message[] = "Por favor, confirma tu asistencia (los enlaces se generarán al guardar):";

--- a/templates/service/new_service.html.twig
+++ b/templates/service/new_service.html.twig
@@ -16,44 +16,6 @@
         #quill-editor, #tasks-editor {
             height: 300px;
         }
-        /* WhatsApp Preview Styles */
-        .whatsapp-preview {
-            background-color: #e5ddd5; /* WhatsApp background color */
-            border-radius: 10px;
-            padding: 20px;
-            font-family: 'Helvetica', sans-serif;
-            border: 1px solid #ccc;
-            width: 100%;
-            max-width: 450px; /* Typical phone width */
-            margin: 0 auto;
-        }
-        .whatsapp-message {
-            background-color: #dcf8c6; /* Sent message bubble color */
-            border-radius: 8px;
-            padding: 10px 15px;
-            position: relative;
-            box-shadow: 0 1px 1px rgba(0,0,0,0.1);
-            white-space: pre-wrap; /* Preserve whitespace and newlines */
-            word-wrap: break-word;
-        }
-        .whatsapp-message::before {
-            content: '';
-            position: absolute;
-            top: 10px;
-            right: -10px;
-            width: 0;
-            height: 0;
-            border: 10px solid transparent;
-            border-left-color: #dcf8c6;
-            border-right: 0;
-            border-top: 0;
-        }
-        .whatsapp-preview h3 {
-            text-align: center;
-            color: #075e54; /* WhatsApp dark green */
-            margin-bottom: 15px;
-            font-weight: bold;
-        }
     </style>
 {% endblock %}
 
@@ -109,7 +71,6 @@
 
             quill.on('text-change', function() {
                 hiddenTextarea.value = quill.root.innerHTML;
-                updateWhatsAppPreview(); // Update preview on text change
             });
 
              // Set initial content from textarea
@@ -121,7 +82,6 @@
         function initializeAllQuillEditors() {
             setupQuill('#quill-editor', '#service_description');
             setupQuill('#tasks-editor', '#service_tasks');
-            updateWhatsAppPreview(); // Initial preview generation
         }
 
         function cleanupQuillInstances() {
@@ -137,78 +97,6 @@
             quillInstances = {};
         }
 
-        async function updateWhatsAppPreview() {
-            const form = document.querySelector('form[name="service"]');
-            if (!form) return;
-
-            const formData = new FormData(form);
-
-            // Create a plain object from FormData
-            const data = {};
-            for (let [key, value] of formData.entries()) {
-                // Handle fields that can have multiple values (like checkboxes)
-                if (key.endsWith('[]')) {
-                    const cleanKey = key.slice(0, -2);
-                    if (!data[cleanKey]) {
-                        data[cleanKey] = [];
-                    }
-                    data[cleanKey].push(value);
-                } else {
-                    data[key] = value;
-                }
-            }
-
-
-            // Manually get content from Quill editors because their content is not in the form data
-            const descriptionEditor = document.querySelector('#quill-editor');
-            if (descriptionEditor && descriptionEditor.quill) {
-                data['service[description]'] = descriptionEditor.quill.root.innerHTML;
-            }
-
-            const tasksEditor = document.querySelector('#tasks-editor');
-            if (tasksEditor && tasksEditor.quill) {
-                data['service[tasks]'] = tasksEditor.quill.root.innerHTML;
-            }
-
-            // Convert the plain object to a structure that mimics the form submission
-            const serviceData = {};
-            for(const key in data) {
-                const match = key.match(/^service\[([^\]]+)\]/);
-                if (match) {
-                    serviceData[match[1]] = data[key];
-                }
-            }
-
-            const finalData = {
-                service: serviceData,
-                description: data['service[description]'],
-                tasks: data['service[tasks]']
-            };
-
-            try {
-                const response = await fetch('{{ path('app_service_preview') }}', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-Requested-With': 'XMLHttpRequest'
-                    },
-                    body: JSON.stringify(finalData)
-                });
-                const result = await response.json();
-                const previewElement = document.getElementById('whatsapp-message-content');
-                if (previewElement) {
-                    previewElement.textContent = result.message || 'Error al generar la vista previa.';
-                }
-            } catch (error) {
-                console.error('Error updating WhatsApp preview:', error);
-                const previewElement = document.getElementById('whatsapp-message-content');
-                if (previewElement) {
-                    previewElement.textContent = 'Error de conexión al generar la vista previa.';
-                }
-            }
-        }
-
-
         // Turbo event listeners
         document.addEventListener('turbo:before-cache', cleanupQuillInstances);
         document.addEventListener('turbo:load', initializeAllQuillEditors);
@@ -218,45 +106,77 @@
             document.addEventListener('DOMContentLoaded', initializeAllQuillEditors);
         }
 
-        function showEditablePreview() {
-            const previewContent = document.getElementById('whatsapp-message-content').textContent;
-            const editorTextarea = document.getElementById('whatsapp-message-editor');
-            // The form field should be created by Symfony form builder, let's target it.
-            const whatsappMessageInput = document.getElementById('service_whatsappMessage');
-
-            if (editorTextarea) {
-                editorTextarea.value = previewContent;
-            }
-            if (whatsappMessageInput) {
-                whatsappMessageInput.value = previewContent;
-            }
-
-            const container = document.getElementById('editable-preview-container');
-            if (container) {
-                container.style.display = 'block';
-            }
-        }
-
-        // Add event listeners to form inputs to update preview
         document.addEventListener('turbo:load', () => {
-             const form = document.querySelector('form[name="service"]');
-             if(form) {
-                form.addEventListener('input', updateWhatsAppPreview);
-             }
+            const form = document.querySelector('form[name="service"]');
+            if (!form) return;
 
-             const previewButton = document.getElementById('preview-button');
-             if (previewButton) {
-                 previewButton.addEventListener('click', showEditablePreview);
-             }
+            form.addEventListener('submit', async (event) => {
+                event.preventDefault(); // Prevent default form submission
 
-             const editorTextarea = document.getElementById('whatsapp-message-editor');
-             const whatsappMessageInput = document.getElementById('service_whatsappMessage');
-             if (editorTextarea && whatsappMessageInput) {
-                 editorTextarea.addEventListener('input', (e) => {
-                     whatsappMessageInput.value = e.target.value;
-                 });
-             }
+                // Manually trigger Quill updates
+                for (const key in quillInstances) {
+                    const quill = quillInstances[key];
+                    const hiddenTextareaId = quill.container.nextElementSibling.id;
+                    document.getElementById(hiddenTextareaId).value = quill.root.innerHTML;
+                }
+
+                const formData = new FormData(form);
+                const button = form.querySelector('button[type="submit"]');
+                button.disabled = true;
+                button.textContent = 'Guardando...';
+
+
+                try {
+                    const response = await fetch('{{ path('app_service_new') }}', {
+                        method: 'POST',
+                        body: formData,
+                        headers: {
+                            'X-Requested-With': 'XMLHttpRequest'
+                        }
+                    });
+
+                    const result = await response.json();
+
+                    if (response.ok && result.success) {
+                        // Show success modal
+                        const modal = document.getElementById('whatsapp-modal');
+                        const textarea = document.getElementById('whatsapp-message-textarea');
+                        textarea.value = result.whatsappMessage;
+                        modal.classList.remove('hidden');
+
+                        // Configure share button
+                        const shareButton = document.getElementById('share-whatsapp-button');
+                        shareButton.onclick = () => {
+                            const message = encodeURIComponent(textarea.value);
+                            window.open(`https://wa.me/?text=${message}`, '_blank');
+                        };
+
+                        // Configure close button
+                        const closeModalButton = document.getElementById('close-modal-button');
+                        closeModalButton.onclick = () => {
+                            modal.classList.add('hidden');
+                             window.location.href = '{{ path('app_services_list') }}';
+                        };
+
+
+                    } else {
+                         // Handle errors
+                        let errorMessages = 'Se ha producido un error al guardar el servicio.';
+                        if (result.errors && result.errors.length > 0) {
+                            errorMessages = result.errors.join('\\n');
+                        }
+                        alert(errorMessages);
+                    }
+                } catch (error) {
+                    console.error('Error submitting form:', error);
+                    alert('Se ha producido un error de red. Por favor, inténtalo de nuevo.');
+                } finally {
+                    button.disabled = false;
+                    button.textContent = 'Guardar Servicio';
+                }
+            });
         });
+
     </script>
 {% endblock %}
 
@@ -264,10 +184,10 @@
     <div class="container mx-auto px-4 py-8">
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {# Form Column #}
-            <div class="lg:col-span-2">
+            <div class="lg:col-span-3">
                 <h1 class="text-3xl font-bold mb-6 text-gray-800">Crear Nuevo Servicio</h1>
                 <div class="bg-white shadow-md rounded-lg p-6">
-                    {{ form_start(serviceForm, {'attr': {'class': 'space-y-8', 'name': 'service'}}) }}
+                    {{ form_start(serviceForm, {'attr': {'class': 'space-y-8', 'name': 'service', 'id': 'service-form'}}) }}
 
                     {# Row 1: Numeración, Título, Lugar (3 columnas) #}
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -439,9 +359,6 @@
                         <a href="{{ path('app_services_list') }}" class="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded-lg transition-colors">
                             Volver a la Lista
                         </a>
-                         <button type="button" id="preview-button" class="bg-yellow-500 hover:bg-yellow-600 text-white font-bold py-2 px-4 rounded-lg transition-colors ml-3">
-                            Previsualizar Mensaje
-                        </button>
                         <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors ml-3">
                             Guardar Servicio
                         </button>
@@ -450,21 +367,26 @@
                     {{ form_end(serviceForm) }}
                 </div>
             </div>
-
-            {# WhatsApp Preview Column #}
-            <div class="lg:col-span-1">
-                <div class="sticky top-8">
-                    <div class="whatsapp-preview">
-                        <h3>Vista Previa de WhatsApp</h3>
-                        <div class="whatsapp-message" id="whatsapp-message-content" style="white-space: pre-wrap; word-wrap: break-word;">
-                            Rellena el formulario para ver el mensaje...
-                        </div>
-                    </div>
-                    <div id="editable-preview-container" class="mt-4" style="display: none;">
-                        <h3 class="text-lg font-semibold mb-2 text-gray-800">Editar Mensaje</h3>
-                        <textarea id="whatsapp-message-editor" class="w-full h-64 p-2 border rounded-md shadow-sm"></textarea>
-                        <p class="text-sm text-gray-500 mt-1">Puedes editar el mensaje aquí antes de guardarlo.</p>
-                    </div>
+        </div>
+    </div>
+    <!-- WhatsApp Share Modal -->
+    <div id="whatsapp-modal" class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
+        <div class="relative top-20 mx-auto p-5 border w-full max-w-2xl shadow-lg rounded-md bg-white">
+            <div class="mt-3 text-center">
+                <h3 class="text-2xl leading-6 font-bold text-gray-900">Servicio Guardado con Éxito</h3>
+                <div class="mt-4 px-7 py-3">
+                    <p class="text-md text-gray-600 mb-4">
+                        El servicio se ha guardado correctamente. A continuación, puedes revisar y editar el mensaje antes de compartirlo en WhatsApp.
+                    </p>
+                    <textarea id="whatsapp-message-textarea" class="w-full h-64 p-3 border rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500"></textarea>
+                </div>
+                <div class="items-center px-4 py-3">
+                    <button id="share-whatsapp-button" class="px-4 py-2 bg-green-500 text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-300">
+                        Compartir en WhatsApp
+                    </button>
+                    <button id="close-modal-button" class="ml-4 px-4 py-2 bg-gray-300 text-gray-800 text-base font-medium rounded-md w-auto shadow-sm hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-200">
+                        Cerrar y Volver a la Lista
+                    </button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This commit refactors the new service creation page to improve the user experience.

The key changes include:
- Removing the live preview of the WhatsApp message and the 'Preview' button.
- After saving a new service, a modal now appears with the generated WhatsApp message.
- The message in the modal is editable, allowing for last-minute changes before sharing.
- The 'Attend' and 'Do not attend' links in the message are formatted to be more user-friendly and clickable in WhatsApp.

These changes were implemented by:
- Modifying the `ServiceController` to handle AJAX requests for form submission.
- Updating the `new_service.html.twig` template to remove preview elements and add a new modal.
- Adding JavaScript to manage the AJAX submission and modal interaction.
- Adjusting the `WhatsAppMessageGenerator` to improve the link formatting.