### PR TITLE
feat: Add user-friendly access denied page

### DIFF
--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -30,4 +30,10 @@ class SecurityController extends AbstractController
     {
         throw new \LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
     }
+
+    #[Route('/access-denied', name: 'app_access_denied')]
+    public function accessDenied(): Response
+    {
+        return $this->render('security/access_denied.html.twig');
+    }
 }

--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -163,7 +163,12 @@ class ServiceController extends AbstractController
         if (!$service) {
             throw $this->createNotFoundException('El servicio solicitado no existe.');
         }
-        $this->denyAccessUnlessGranted('ROLE_VOLUNTEER');
+
+        if (!$this->isGranted('ROLE_VOLUNTEER')) {
+            $this->addFlash('warning', 'Necesitas ser voluntario para inscribirte a un servicio.');
+            return $this->redirectToRoute('app_access_denied');
+        }
+
         $user = $security->getUser();
         $volunteer = $user->getVolunteer();
         $assistanceConfirmation = $assistanceConfirmationRepository->findOneBy(['volunteer' => $volunteer, 'service' => $service]);
@@ -185,7 +190,12 @@ class ServiceController extends AbstractController
         if (!$service) {
             throw $this->createNotFoundException('El servicio solicitado no existe.');
         }
-        $this->denyAccessUnlessGranted('ROLE_VOLUNTEER');
+
+        if (!$this->isGranted('ROLE_VOLUNTEER')) {
+            $this->addFlash('warning', 'Necesitas ser voluntario para anular tu asistencia a un servicio.');
+            return $this->redirectToRoute('app_access_denied');
+        }
+
         $user = $security->getUser();
         $volunteer = $user->getVolunteer();
         $assistanceConfirmation = $assistanceConfirmationRepository->findOneBy(['volunteer' => $volunteer, 'service' => $service]);

--- a/templates/security/access_denied.html.twig
+++ b/templates/security/access_denied.html.twig
@@ -1,0 +1,17 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Acceso Denegado{% endblock %}
+
+{% block body %}
+<div class="flex items-center justify-center min-h-screen bg-gray-100">
+    <div class="max-w-md w-full bg-white p-8 rounded-lg shadow-md text-center">
+        <h1 class="text-2xl font-bold text-gray-800 mb-4">Acceso Denegado</h1>
+        <p class="text-gray-600 mb-6">
+            Para realizar esta acción, primero debes estar registrado como voluntario.
+        </p>
+        <a href="{{ path('app_volunteer_registration') }}" class="w-full bg-blue-500 text-white py-2 px-4 rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50">
+            Inscribirme como voluntario
+        </a>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Instead of showing a generic 403 Forbidden error page when a non-volunteer user tries to sign up for a service, this change introduces a more user-friendly access denied page.

The new page explains to the user that they need to be a registered volunteer to perform the action and provides a direct link to the volunteer registration form.

This improves the user experience by providing clear feedback and a path to resolution.

Changes include:
- A new route and controller action for the access denied page in `SecurityController`.
- A new Twig template for the access denied page.
- Modification of the `attend` and `unattend` actions in `ServiceController` to redirect non-volunteer users to the new page.