### PR TITLE
fix: Correct Twig syntax in service attendance lists

### DIFF
--- a/templates/service/edit_service.html.twig
+++ b/templates/service/edit_service.html.twig
@@ -243,7 +243,7 @@
                         <span class="bg-green-200 text-green-800 text-sm font-bold px-2 py-1 rounded-full">{{ service.getAttendingVolunteers|length }}</span>
                     </h4>
                     <ul class="list-group space-y-2">
-                        {% for confirmation in service.assistanceConfirmations if confirmation.status == 'attends' %}
+                        {% for confirmation in service.assistanceConfirmations|filter(c => c.status == 'attends') %}
                             <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm">{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</li>
                         {% else %}
                             <li class="list-group-item text-gray-500 italic">Nadie asiste todavía.</li>
@@ -257,7 +257,7 @@
                         <span class="bg-yellow-200 text-yellow-800 text-sm font-bold px-2 py-1 rounded-full">{{ service.getReserveVolunteers|length }}</span>
                     </h4>
                     <ul class="list-group space-y-2">
-                        {% for confirmation in service.assistanceConfirmations if confirmation.status == 'reserve' %}
+                        {% for confirmation in service.assistanceConfirmations|filter(c => c.status == 'reserve') %}
                            <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm">{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</li>
                         {% else %}
                             <li class="list-group-item text-gray-500 italic">No hay nadie en reserva.</li>
@@ -271,7 +271,7 @@
                         <span class="bg-red-200 text-red-800 text-sm font-bold px-2 py-1 rounded-full">{{ service.getNotAttendingVolunteers|length }}</span>
                     </h4>
                     <ul class="list-group space-y-2">
-                        {% for confirmation in service.assistanceConfirmations if confirmation.status == 'not_attends' %}
+                        {% for confirmation in service.assistanceConfirmations|filter(c => c.status == 'not_attends') %}
                             <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm">{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</li>
                         {% else %}
                             <li class="list-group-item text-gray-500 italic">Nadie ha cancelado.</li>


### PR DESCRIPTION
This commit fixes a Twig syntax error in `templates/service/edit_service.html.twig`. The `if` condition was incorrectly placed inside the `for` loop declaration.

The code has been updated to use the `filter` filter to correctly select the items from the collection before iterating over them. This resolves the `Unexpected token "name" of value "if"` error and allows the page to render correctly.