### PR TITLE
fix: Align attendance logic with database schema

### DIFF
--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -231,7 +231,8 @@ class ServiceController extends AbstractController
                     $confirmation->setVolunteer($volunteer);
                     $entityManager->persist($confirmation);
                 }
-                $confirmation->setStatus($status);
+                $attends = ($status === 'attends');
+                $confirmation->setHasAttended($attends);
             }
         }
 

--- a/templates/service/edit_service.html.twig
+++ b/templates/service/edit_service.html.twig
@@ -236,14 +236,14 @@
                 </button>
             </div>
 
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
                 <div>
                     <h4 class="text-lg font-semibold mb-3 p-3 bg-green-100 text-green-800 rounded-lg flex justify-between items-center">
                         <span>Asisten</span>
-                        <span class="bg-green-200 text-green-800 text-sm font-bold px-2 py-1 rounded-full">{{ service.assistanceConfirmations|filter(c => c.status == 'attends')|length }}</span>
+                        <span class="bg-green-200 text-green-800 text-sm font-bold px-2 py-1 rounded-full">{{ service.assistanceConfirmations|filter(c => c.isHasAttended() == true)|length }}</span>
                     </h4>
                     <ul class="list-group space-y-2">
-                        {% for confirmation in service.assistanceConfirmations|filter(c => c.status == 'attends') %}
+                        {% for confirmation in service.assistanceConfirmations|filter(c => c.isHasAttended() == true) %}
                             <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm">{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</li>
                         {% else %}
                             <li class="list-group-item text-gray-500 italic">Nadie asiste todavía.</li>
@@ -252,26 +252,12 @@
                 </div>
 
                 <div>
-                    <h4 class="text-lg font-semibold mb-3 p-3 bg-yellow-100 text-yellow-800 rounded-lg flex justify-between items-center">
-                        <span>En Reserva</span>
-                        <span class="bg-yellow-200 text-yellow-800 text-sm font-bold px-2 py-1 rounded-full">{{ service.assistanceConfirmations|filter(c => c.status == 'reserve')|length }}</span>
-                    </h4>
-                    <ul class="list-group space-y-2">
-                        {% for confirmation in service.assistanceConfirmations|filter(c => c.status == 'reserve') %}
-                           <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm">{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</li>
-                        {% else %}
-                            <li class="list-group-item text-gray-500 italic">No hay nadie en reserva.</li>
-                        {% endfor %}
-                    </ul>
-                </div>
-
-                <div>
                     <h4 class="text-lg font-semibold mb-3 p-3 bg-red-100 text-red-800 rounded-lg flex justify-between items-center">
                         <span>No Asisten</span>
-                        <span class="bg-red-200 text-red-800 text-sm font-bold px-2 py-1 rounded-full">{{ service.assistanceConfirmations|filter(c => c.status == 'not_attends')|length }}</span>
+                        <span class="bg-red-200 text-red-800 text-sm font-bold px-2 py-1 rounded-full">{{ service.assistanceConfirmations|filter(c => c.isHasAttended() == false)|length }}</span>
                     </h4>
                     <ul class="list-group space-y-2">
-                        {% for confirmation in service.assistanceConfirmations|filter(c => c.status == 'not_attends') %}
+                        {% for confirmation in service.assistanceConfirmations|filter(c => c.isHasAttended() == false) %}
                             <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm">{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</li>
                         {% else %}
                             <li class="list-group-item text-gray-500 italic">Nadie ha cancelado.</li>
@@ -304,7 +290,6 @@
             <label for="attendance-status-select" class="block text-sm font-medium text-gray-700 mb-2">Marcar como:</label>
             <select data-service-form-target="attendanceStatusSelect" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500">
                 <option value="attends">Asiste</option>
-                <option value="reserve">En Reserva</option>
                 <option value="not_attends">No Asiste</option>
             </select>
         </div>


### PR DESCRIPTION
This commit provides a comprehensive fix for the attendance management feature by aligning the frontend, controller, and templates with the actual database schema.

The root cause of the recent errors was a mismatch between the UI, which used a three-state status ('attends', 'reserve', 'not_attends'), and the `AssistanceConfirmation` entity, which only supports a boolean `hasAttended` property.

The following changes have been made:
- The `updateAttendance` method in `ServiceController.php` has been corrected to handle a boolean attendance status.
- The "reserve" option has been removed from the attendance modal UI in `edit_service.html.twig`.
- The attendance lists in `edit_service.html.twig` have been updated to use the correct `isHasAttended()` method for filtering and counting, and the "reserve" list has been removed.

These changes ensure that the application correctly reflects the data model, resolving the series of Twig runtime errors.