### PR TITLE
fix: Remove CSS directives from JS file causing SyntaxError

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,7 +1,4 @@
 import './bootstrap.js';
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
 /*
  * Welcome to your app's main JavaScript file!
  *


### PR DESCRIPTION
This commit fixes a critical `SyntaxError` in the main JavaScript entrypoint (`assets/app.js`). The file incorrectly contained `@tailwind` CSS directives, which are not valid JavaScript, causing the browser to fail to parse the entire file.

This error prevented any of the application's JavaScript from running, which was the root cause of the long-standing issue where the Quill editor and other interactive elements were not initializing.

The offending lines have been removed from `assets/app.js`. They were already correctly present in `assets/styles/app.css`.

This resolves the `Uncaught SyntaxError: Invalid or unexpected token` and should restore all JavaScript functionality to the application.