### PR TITLE
fix: Correctly import Quill CSS

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -6,6 +6,5 @@ import './bootstrap.js';
  * which should already be in your base.html.twig.
  */
 import './styles/app.css';
-import 'quill/dist/quill.snow.css';
 
 console.log('This log comes from assets/app.js - welcome to AssetMapper! 🎉');

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,3 +1,4 @@
+@import "quill/dist/quill.snow.css";
 /* assets/styles/app.css (o login.css) */
 
 @tailwind base;


### PR DESCRIPTION
This commit fixes a `TypeError` caused by an incorrect attempt to import a CSS file from JavaScript. The `import 'quill/dist/quill.snow.css'` statement in `assets/app.js` was failing because the path was not defined in the import map.

The fix involves removing the JavaScript import and instead using a standard CSS `@import` statement in `assets/styles/app.css`. This is the correct and idiomatic way to include package CSS when using Symfony's AssetMapper.

This resolves the `Failed to resolve module specifier` error and should allow the Quill editor and its stylesheet to load correctly.