### PR TITLE
Fix Quill editor toolbar and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log
 tailwindcss.exe
 /var/cache/
 
+###> symfony/asset-mapper ###
+/assets/vendor/
+###< symfony/asset-mapper ###

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -11,3 +11,22 @@
 /* body {
     background-color: lightblue;
 } */
+
+/* Quill editor toolbar fix for Tailwind CSS conflict */
+.ql-toolbar {
+    display: block !important;
+    visibility: visible !important;
+    position: relative !important;
+}
+
+.ql-toolbar .ql-formats {
+    display: inline-block !important;
+    margin-right: 15px;
+}
+
+.ql-toolbar button {
+    display: inline-block !important;
+    width: 28px;
+    height: 24px;
+    padding: 3px 5px;
+}


### PR DESCRIPTION
- Add CSS overrides to fix a conflict between Tailwind CSS and the Quill editor toolbar, ensuring the toolbar is always visible.
- Add `/assets/vendor/` to `.gitignore` to prevent vendor files from being committed to the repository, which is a standard practice for Symfony projects using AssetMapper.