### PR TITLE
Fix(service): Move tasks field definition in ServiceType

### DIFF
--- a/src/Form/ServiceType.php
+++ b/src/Form/ServiceType.php
@@ -93,6 +93,10 @@ class ServiceType extends AbstractType
                 'label' => 'Descripción',
                 'required' => false,
             ])
+            ->add('tasks', TextareaType::class, [
+                'label' => 'Tareas',
+                'required' => false,
+            ])
             ->add('recipients', ChoiceType::class, [
                 'label' => 'Destinatarios del Servicio',
                 'choices' => [
@@ -152,10 +156,6 @@ class ServiceType extends AbstractType
             ])
             ->add('hasFieldHospital', CheckboxType::class, [
                 'label' => 'Hospital de Campaña',
-                'required' => false,
-            ])
-            ->add('tasks', TextareaType::class, [
-                'label' => 'Tareas',
                 'required' => false,
             ])
             ->add('hasProvisions', CheckboxType::class, [


### PR DESCRIPTION
The 'Tareas' field was not rendering correctly on the 'Crear Nuevo Servicio' page. The rich text editor for this field was missing.

This was caused by the order of the field definition in the `ServiceType.php` form class.

By moving the `tasks` field definition to be immediately after the `description` field, the rendering order is corrected and the Quill.js editor for the `tasks` field now appears as expected.