### PR TITLE
feat: Implement modal for adding volunteers to service attendance

### DIFF
--- a/templates/service/edit_service.html.twig
+++ b/templates/service/edit_service.html.twig
@@ -275,45 +275,57 @@
 
 <!-- Add User Modal -->
 <div class="hidden fixed inset-0 bg-gray-800 bg-opacity-60 flex items-center justify-center z-50" data-service-form-target="modal">
-    <div class="modal-content bg-white rounded-2xl shadow-2xl p-8 max-w-2xl w-full mx-4">
-        <h3 class="text-2xl font-bold text-gray-900 mb-6">Añadir Voluntarios al Servicio</h3>
-
-        <div class="relative mb-4">
-            <input type="text" data-service-form-target="userSearchInput" data-action="keyup->service-form#search" placeholder="Buscar por nombre, apellido o ID..." class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 pr-10">
-            <button type="button" class="absolute inset-y-0 right-0 flex items-center pr-3" data-action="click->service-form#clearSearch">
-                <i data-lucide="x-circle" class="h-5 w-5 text-gray-400 hover:text-gray-600"></i>
+    <div class="modal-content bg-white rounded-2xl shadow-2xl p-8 max-w-3xl w-full mx-4">
+        <div class="flex justify-between items-center mb-6 border-b pb-4">
+            <h3 class="text-2xl font-bold text-gray-900">Agregar respuestas</h3>
+            <button type="button" data-action="click->service-form#closeModal" class="text-gray-400 hover:text-gray-600">
+                <i data-lucide="x" class="h-6 w-6"></i>
             </button>
         </div>
 
-        <div data-service-form-target="userList" class="space-y-2 mb-4" style="min-height: 200px;">
+        <div class="mb-4">
+            <label for="attendance-status-select" class="block text-sm font-medium text-gray-700 mb-1">Respuesta <span class="text-red-500">*</span></label>
+            <select data-service-form-target="attendanceStatusSelect" id="attendance-status-select" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500">
+                <option value="" selected disabled>Selecciona...</option>
+                <option value="attends">Asiste</option>
+                <option value="not_attends">No asiste</option>
+            </select>
+        </div>
+
+        <div class="flex justify-between items-center mb-4">
+            <div>
+                <label for="items-per-page" class="text-sm font-medium text-gray-700 mr-2">Mostrar:</label>
+                <select id="items-per-page" data-service-form-target="itemsPerPageSelect" data-action="change->service-form#search" class="rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                    <option>10</option>
+                    <option>25</option>
+                    <option selected>50</option>
+                    <option>100</option>
+                </select>
+                 <span class="text-sm text-gray-600 ml-2">registros</span>
+            </div>
+            <div class="relative">
+                <span class="absolute inset-y-0 left-0 flex items-center pl-3">
+                    <i data-lucide="search" class="h-5 w-5 text-gray-400"></i>
+                </span>
+                <input type="text" data-service-form-target="userSearchInput" data-action="keyup->service-form#search" placeholder="Buscar..." class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 pl-10">
+            </div>
+        </div>
+
+        <div data-service-form-target="userList" class="space-y-1 mb-4 border rounded-lg p-2" style="min-height: 200px; max-height: 40vh; overflow-y: auto;">
             <!-- Volunteer list will be populated here -->
         </div>
 
         <div class="flex justify-between items-center mb-6">
-            <div>
-                <label for="items-per-page" class="text-sm font-medium text-gray-700 mr-2">Mostrar:</label>
-                <select id="items-per-page" data-service-form-target="itemsPerPageSelect" data-action="change->service-form#search" class="rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                    <option>25</option>
-                    <option>50</option>
-                    <option>100</option>
-                </select>
+            <div data-service-form-target="paginationSummary" class="text-sm text-gray-700">
+                <!-- Pagination summary will be populated here -->
             </div>
             <div data-service-form-target="paginationContainer" class="flex justify-center items-center">
                 <!-- Pagination controls will be populated here -->
             </div>
         </div>
 
-        <div class="mb-6">
-            <label for="attendance-status-select" class="block text-sm font-medium text-gray-700 mb-2">Marcar como:</label>
-            <select data-service-form-target="attendanceStatusSelect" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500">
-                <option value="attends">Asiste</option>
-                <option value="not_attends">No Asiste</option>
-            </select>
-        </div>
-
-        <div class="flex justify-end space-x-4">
-            <button type="button" data-action="click->service-form#closeModal" class="px-6 py-3 bg-gray-300 text-gray-800 font-semibold rounded-lg shadow-md hover:bg-gray-400">Cancelar</button>
-            <button type="button" data-action="click->service-form#saveAttendance" class="px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700">Guardar Cambios</button>
+        <div class="flex justify-end space-x-4 border-t pt-4">
+            <button type="button" data-action="click->service-form#saveAttendance" class="px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700">Aceptar</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This commit introduces a modal window for adding volunteers to the attendance confirmation list of a service. The new modal improves user experience by allowing coordinators to add volunteers without leaving the service editing page.

Key changes:
- Modified `templates/service/edit_service.html.twig` to include the HTML structure for the new modal, designed according to the provided UI screenshot.
- Updated `assets/controllers/service_form_controller.js` to manage the modal's functionality, including:
  - Opening and closing the modal.
  - Fetching and displaying a paginated list of volunteers with search functionality.
  - Handling volunteer selection via checkboxes.
  - Saving the attendance status for the selected volunteers.
- The modal UI includes a response dropdown, a search bar, a volunteer list, and pagination controls, providing a comprehensive and user-friendly interface.