### PR TITLE
fix: Resolve JavaScript errors in service form controller

### DIFF
--- a/assets/controllers/service_form_controller.js
+++ b/assets/controllers/service_form_controller.js
@@ -19,9 +19,6 @@ export default class extends Controller {
 
     connect() {
         this.initializeQuill();
-        if (this.hasTabLinkTarget) {
-            this.setupTabs();
-        }
         if (this.hasModalTarget) {
             this.setupAttendanceModal();
         }
@@ -82,16 +79,9 @@ export default class extends Controller {
         return quill;
     }
 
-    setupTabs() {
-        this.tabLinkTargets.forEach(link => {
-            link.addEventListener('click', (event) => {
-                event.preventDefault();
-                this.switchTab(event.currentTarget);
-            });
-        });
-    }
-
-    switchTab(clickedLink) {
+    switchTab(event) {
+        event.preventDefault();
+        const clickedLink = event.currentTarget;
         this.tabLinkTargets.forEach(link => link.classList.remove('active'));
         clickedLink.classList.add('active');
 

--- a/templates/service/edit_service.html.twig
+++ b/templates/service/edit_service.html.twig
@@ -271,61 +271,61 @@
             </div>
         </div>
     </div>
-</div>
 
-<!-- Add User Modal -->
-<div class="hidden fixed inset-0 bg-gray-800 bg-opacity-60 flex items-center justify-center z-50" data-service-form-target="modal">
-    <div class="modal-content bg-white rounded-2xl shadow-2xl p-8 max-w-3xl w-full mx-4">
-        <div class="flex justify-between items-center mb-6 border-b pb-4">
-            <h3 class="text-2xl font-bold text-gray-900">Agregar respuestas</h3>
-            <button type="button" data-action="click->service-form#closeModal" class="text-gray-400 hover:text-gray-600">
-                <i data-lucide="x" class="h-6 w-6"></i>
-            </button>
-        </div>
+    <!-- Add User Modal -->
+    <div class="hidden fixed inset-0 bg-gray-800 bg-opacity-60 flex items-center justify-center z-50" data-service-form-target="modal">
+        <div class="modal-content bg-white rounded-2xl shadow-2xl p-8 max-w-3xl w-full mx-4">
+            <div class="flex justify-between items-center mb-6 border-b pb-4">
+                <h3 class="text-2xl font-bold text-gray-900">Agregar respuestas</h3>
+                <button type="button" data-action="click->service-form#closeModal" class="text-gray-400 hover:text-gray-600">
+                    <i data-lucide="x" class="h-6 w-6"></i>
+                </button>
+            </div>
 
-        <div class="mb-4">
-            <label for="attendance-status-select" class="block text-sm font-medium text-gray-700 mb-1">Respuesta <span class="text-red-500">*</span></label>
-            <select data-service-form-target="attendanceStatusSelect" id="attendance-status-select" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500">
-                <option value="" selected disabled>Selecciona...</option>
-                <option value="attends">Asiste</option>
-                <option value="not_attends">No asiste</option>
-            </select>
-        </div>
-
-        <div class="flex justify-between items-center mb-4">
-            <div>
-                <label for="items-per-page" class="text-sm font-medium text-gray-700 mr-2">Mostrar:</label>
-                <select id="items-per-page" data-service-form-target="itemsPerPageSelect" data-action="change->service-form#search" class="rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                    <option>10</option>
-                    <option>25</option>
-                    <option selected>50</option>
-                    <option>100</option>
+            <div class="mb-4">
+                <label for="attendance-status-select" class="block text-sm font-medium text-gray-700 mb-1">Respuesta <span class="text-red-500">*</span></label>
+                <select data-service-form-target="attendanceStatusSelect" id="attendance-status-select" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500">
+                    <option value="" selected disabled>Selecciona...</option>
+                    <option value="attends">Asiste</option>
+                    <option value="not_attends">No asiste</option>
                 </select>
-                 <span class="text-sm text-gray-600 ml-2">registros</span>
             </div>
-            <div class="relative">
-                <span class="absolute inset-y-0 left-0 flex items-center pl-3">
-                    <i data-lucide="search" class="h-5 w-5 text-gray-400"></i>
-                </span>
-                <input type="text" data-service-form-target="userSearchInput" data-action="keyup->service-form#search" placeholder="Buscar..." class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 pl-10">
-            </div>
-        </div>
 
-        <div data-service-form-target="userList" class="space-y-1 mb-4 border rounded-lg p-2" style="min-height: 200px; max-height: 40vh; overflow-y: auto;">
-            <!-- Volunteer list will be populated here -->
-        </div>
-
-        <div class="flex justify-between items-center mb-6">
-            <div data-service-form-target="paginationSummary" class="text-sm text-gray-700">
-                <!-- Pagination summary will be populated here -->
+            <div class="flex justify-between items-center mb-4">
+                <div>
+                    <label for="items-per-page" class="text-sm font-medium text-gray-700 mr-2">Mostrar:</label>
+                    <select id="items-per-page" data-service-form-target="itemsPerPageSelect" data-action="change->service-form#search" class="rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                        <option>10</option>
+                        <option>25</option>
+                        <option selected>50</option>
+                        <option>100</option>
+                    </select>
+                     <span class="text-sm text-gray-600 ml-2">registros</span>
+                </div>
+                <div class="relative">
+                    <span class="absolute inset-y-0 left-0 flex items-center pl-3">
+                        <i data-lucide="search" class="h-5 w-5 text-gray-400"></i>
+                    </span>
+                    <input type="text" data-service-form-target="userSearchInput" data-action="keyup->service-form#search" placeholder="Buscar..." class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 pl-10">
+                </div>
             </div>
-            <div data-service-form-target="paginationContainer" class="flex justify-center items-center">
-                <!-- Pagination controls will be populated here -->
-            </div>
-        </div>
 
-        <div class="flex justify-end space-x-4 border-t pt-4">
-            <button type="button" data-action="click->service-form#saveAttendance" class="px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700">Aceptar</button>
+            <div data-service-form-target="userList" class="space-y-1 mb-4 border rounded-lg p-2" style="min-height: 200px; max-height: 40vh; overflow-y: auto;">
+                <!-- Volunteer list will be populated here -->
+            </div>
+
+            <div class="flex justify-between items-center mb-6">
+                <div data-service-form-target="paginationSummary" class="text-sm text-gray-700">
+                    <!-- Pagination summary will be populated here -->
+                </div>
+                <div data-service-form-target="paginationContainer" class="flex justify-center items-center">
+                    <!-- Pagination controls will be populated here -->
+                </div>
+            </div>
+
+            <div class="flex justify-end space-x-4 border-t pt-4">
+                <button type="button" data-action="click->service-form#saveAttendance" class="px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700">Aceptar</button>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This commit addresses two critical JavaScript errors that were introduced in the previous implementation of the volunteer-adding modal:

1.  **Missing Target Element Error:** The modal's HTML was incorrectly placed outside the scope of the Stimulus controller's main element, causing a "Missing target element 'modal'" error. This has been resolved by moving the modal's `div` inside the controller's `div` in `templates/service/edit_service.html.twig`.

2.  **Tab Switching TypeError:** A `TypeError` was occurring when switching tabs due to a combination of a redundant event listener setup and an incorrect method signature in the Stimulus controller. The `setupTabs` method was removed, and the `switchTab` method was refactored to correctly handle the `event` object passed by the `data-action` attribute, which is the standard Stimulus practice.

These fixes ensure that both the modal and the tab-switching functionalities work as expected, restoring the intended user experience on the service editing page.