### PR TITLE
fix: Finalize and correct the add volunteer modal

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -6,5 +6,6 @@ import './bootstrap.js';
  * which should already be in your base.html.twig.
  */
 import './styles/app.css';
+import 'quill/dist/quill.snow.css';
 
 console.log('This log comes from assets/app.js - welcome to AssetMapper! 🎉');

--- a/assets/controllers/service_form_controller.js
+++ b/assets/controllers/service_form_controller.js
@@ -200,16 +200,16 @@ renderPagination(pagination, items) {
         button.innerHTML = text;
         button.disabled = disabled;
         button.className = `px-3 py-1 mx-1 rounded-lg text-sm ${active ? 'bg-blue-500 text-white' : 'bg-gray-200 hover:bg-gray-300 disabled:opacity-50'}`;
-        if (!active) {
-            button.addEventListener('click', () => this.fetchVolunteers(page, this.userSearchInputTarget.value));
-        }
+        button.addEventListener('click', () => this.fetchVolunteers(page, this.userSearchInputTarget.value));
         return button;
     };
 
     this.paginationContainerTarget.appendChild(createButton('Anterior', pagination.currentPage - 1, pagination.currentPage === 1));
 
-    // Simplified pagination links
-    this.paginationContainerTarget.appendChild(createButton(pagination.currentPage, pagination.currentPage, false, true));
+    for (let i = 1; i <= pagination.totalPages; i++) {
+        const pageButton = createButton(i, i, false, i === pagination.currentPage);
+        this.paginationContainerTarget.appendChild(pageButton);
+    }
 
     this.paginationContainerTarget.appendChild(createButton('Siguiente', pagination.currentPage + 1, pagination.currentPage === pagination.totalPages));
     }

--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -164,7 +164,7 @@ class ServiceController extends AbstractController
     #[Route('/services/{id}/volunteers', name: 'app_service_get_volunteers', methods: ['GET'])]
     public function getVolunteers(Request $request, Service $service, VolunteerRepository $volunteerRepository, PaginatorInterface $paginator): JsonResponse
     {
-        $this->denyAccessUnlessGranted('ROLE_COORDINATOR');
+    $this->denyAccessUnlessGranted('ROLE_ADMIN');
 
         $queryBuilder = $volunteerRepository->createQueryBuilder('v')
             ->leftJoin('v.assistanceConfirmations', 'ac', 'WITH', 'ac.service = :service')
@@ -211,7 +211,7 @@ class ServiceController extends AbstractController
     #[Route('/services/{id}/update-attendance', name: 'app_service_update_attendance', methods: ['POST'])]
     public function updateAttendance(Request $request, Service $service, EntityManagerInterface $entityManager, VolunteerRepository $volunteerRepository, AssistanceConfirmationRepository $assistanceConfirmationRepository): JsonResponse
     {
-        $this->denyAccessUnlessGranted('ROLE_COORDINATOR');
+    $this->denyAccessUnlessGranted('ROLE_ADMIN');
 
         $data = json_decode($request->getContent(), true);
         $volunteerIds = $data['volunteerIds'] ?? [];


### PR DESCRIPTION
This commit includes several fixes and improvements to the 'Add Volunteer' modal feature, addressing issues identified during testing and code review.

Key changes:
1.  **Security Role Update:** As per the user's request, the required role to access the volunteer list and update attendance has been changed from `ROLE_COORDINATOR` to `ROLE_ADMIN` in `ServiceController.php`.
2.  **Fix Missing CSS:** The `quill.snow.css` file, which was consistently causing a 404 error, is now correctly imported in `assets/app.js`, resolving the styling issue for the Quill rich text editor.
3.  **Restore Pagination Controls:** The pagination functionality in the modal was broken in a previous commit. This has been fixed by restoring the loop in the `renderPagination` function in `service_form_controller.js` to generate all necessary page navigation buttons.

These changes finalize the feature, ensuring it is both functional and meets the user's requirements.