### PR TITLE
Feat: Auto-login with admin role in test environment

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
 # define your env variables for the test env here
+APP_ENV=test
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -26,6 +26,7 @@ security:
             logout:
                 path: app_logout
                 target: app_login
+            switch_user: true
 
     role_hierarchy:
         ROLE_ADVISER: ROLE_USER

--- a/config/packages/test/services.yaml
+++ b/config/packages/test/services.yaml
@@ -1,0 +1,6 @@
+services:
+    App\EventListener\TestEnvironmentAutoLoginListener:
+        arguments:
+            $environment: '%kernel.environment%'
+        tags:
+            - { name: 'kernel.event_subscriber' }

--- a/src/Controller/TestLoginController.php
+++ b/src/Controller/TestLoginController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+#[Route('/test')]
+class TestLoginController extends AbstractController
+{
+    #[Route('/login_admin', name: 'test_login_admin', methods: ['GET'])]
+    public function loginAdmin(
+        Request $request,
+        EntityManagerInterface $em,
+        UserPasswordHasherInterface $passwordHasher,
+        TokenStorageInterface $tokenStorage
+    ): Response {
+        if ($this->getParameter('kernel.environment') !== 'test') {
+            throw $this->createNotFoundException('This route is only available in the test environment.');
+        }
+
+        $email = 'admin@voluntarios.org';
+        $password = 'admin123';
+
+        $userRepository = $em->getRepository(User::class);
+        $user = $userRepository->findOneBy(['email' => $email]);
+
+        if (!$user) {
+            $user = new User();
+            $user->setEmail($email);
+            $user->setRoles(['ROLE_ADMIN']);
+            $hashedPassword = $passwordHasher->hashPassword($user, $password);
+            $user->setPassword($hashedPassword);
+            $em->persist($user);
+            $em->flush();
+        }
+
+        $token = new UsernamePasswordToken($user, 'main', $user->getRoles());
+        $tokenStorage->setToken($token);
+
+        $request->getSession()->set('_security_main', serialize($token));
+
+        return $this->redirectToRoute('app_dashboard');
+    }
+}

--- a/src/EventListener/TestEnvironmentAutoLoginListener.php
+++ b/src/EventListener/TestEnvironmentAutoLoginListener.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class TestEnvironmentAutoLoginListener implements EventSubscriberInterface
+{
+    private $urlGenerator;
+    private $environment;
+    private $tokenStorage;
+
+    public function __construct(UrlGeneratorInterface $urlGenerator, string $environment, TokenStorageInterface $tokenStorage)
+    {
+        $this->urlGenerator = $urlGenerator;
+        $this->environment = $environment;
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    public function onKernelRequest(RequestEvent $event)
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        // If a user is already logged in, do nothing
+        if ($this->tokenStorage->getToken()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $currentRoute = $request->attributes->get('_route');
+
+        if ($this->environment === 'test' && $currentRoute !== 'test_login_admin' && $currentRoute !== '_wdt') {
+            $url = $this->urlGenerator->generate('test_login_admin');
+            $event->setResponse(new RedirectResponse($url));
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => 'onKernelRequest',
+        ];
+    }
+}


### PR DESCRIPTION
This commit introduces an automatic login feature for the test environment. When the application is running in the `test` environment, it will automatically log in a user with the `ROLE_ADMIN`.

This is achieved by:
- Creating a new controller that handles the creation and authentication of an admin user.
- Creating a new event listener that intercepts requests in the test environment and redirects unauthenticated users to the test login route.
- The admin user `admin@voluntarios.org` is created with the password `admin123` if it does not exist.