### PR TITLE
Fix: Missing use statement in ServiceController

### DIFF
--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -7,6 +7,7 @@ use App\Form\ServiceType;
 use App\Repository\AssistanceConfirmationRepository;
 use App\Repository\ServiceRepository;
 use App\Repository\VolunteerRepository;
+use App\Entity\VolunteerService;
 use App\Service\WhatsAppMessageGenerator;
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\Component\Pager\PaginatorInterface;


### PR DESCRIPTION
This commit fixes a bug that caused an error when accessing the "Confirmación de Asistencia" page. The error was caused by a missing `use` statement for the `VolunteerService` entity in the `ServiceController`.