### PR TITLE
Fix: Resolve autowiring error for DevEnvironmentAutoLoginListener

### DIFF
--- a/config/packages/dev/services.yaml
+++ b/config/packages/dev/services.yaml
@@ -1,6 +1,0 @@
-services:
-    App\EventListener\DevEnvironmentAutoLoginListener:
-        arguments:
-            $environment: '%kernel.environment%'
-        tags:
-            - { name: 'kernel.event_subscriber' }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -19,3 +19,11 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+
+when@dev:
+    services:
+        App\EventListener\DevEnvironmentAutoLoginListener:
+            arguments:
+                $environment: '%kernel.environment%'
+            tags:
+                - { name: 'kernel.event_subscriber' }


### PR DESCRIPTION
This commit fixes a `RuntimeException` caused by an autowiring failure for the `DevEnvironmentAutoLoginListener` service.

The previous implementation used an environment-specific configuration file (`config/packages/dev/services.yaml`), which was not being loaded correctly in the user's environment.

This commit moves the service definition to the main `config/services.yaml` file and wraps it in a `when@dev` condition. This is a more robust way to apply environment-specific configuration and resolves the autowiring error.