### PR TITLE
feat: Add admin auto-login for development

### DIFF
--- a/config/routes/web_profiler.yaml
+++ b/config/routes/web_profiler.yaml
@@ -6,3 +6,8 @@ when@dev:
     web_profiler_profiler:
         resource: '@WebProfilerBundle/Resources/config/routing/profiler.php'
         prefix: /_profiler
+
+    app_auto_login:
+        path: /auto-login/{id}
+        controller: App\Controller\SecurityController::autoLogin
+        methods: [GET]


### PR DESCRIPTION
This commit introduces an auto-login feature for users with the `ROLE_ADMIN` role, intended for use in the development environment only.

A new route, `/auto-login/{id}`, has been added. When accessed in the `dev` environment, it authenticates the user with the specified ID and redirects them to the dashboard.

This feature is restricted to administrators and is unavailable in the production environment to ensure security.