### PR TITLE
feat: Add admin auto-login for development

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -34,6 +34,7 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
+        - { path: ^/auto-login, roles: PUBLIC_ACCESS }
         - { path: ^/login, roles: PUBLIC_ACCESS }
         - { path: ^/servicios/new, roles: ROLE_ADMIN }
         - { path: ^/servicios/\d+/editar, roles: ROLE_ADMIN }


### PR DESCRIPTION
This commit introduces an auto-login feature for users with the `ROLE_ADMIN` role, intended for use in the development environment only.

A new route, `/auto-login/{id}`, has been added. When accessed in the `dev` environment, it authenticates the user with the specified ID and redirects them to the dashboard.

This feature is restricted to administrators and is unavailable in the production environment to ensure security.

A new access control rule has been added to `security.yaml` to allow public access to the auto-login route, which is necessary for the feature to work.