### PR TITLE
fix(security): Use email to find auto-login user

### DIFF
--- a/src/EventSubscriber/DevAutoLoginSubscriber.php
+++ b/src/EventSubscriber/DevAutoLoginSubscriber.php
@@ -14,7 +14,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class DevAutoLoginSubscriber implements EventSubscriberInterface
 {
-    private const DEFAULT_ADMIN_USER_ID = 1;
+    private const DEFAULT_ADMIN_EMAIL = 'admin@voluntarios.org';
 
     public function __construct(
         private readonly KernelInterface $kernel,
@@ -34,7 +34,7 @@ class DevAutoLoginSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $user = $this->userRepository->find(self::DEFAULT_ADMIN_USER_ID);
+        $user = $this->userRepository->findOneBy(['email' => self::DEFAULT_ADMIN_EMAIL]);
 
         if (!$user) {
             return;


### PR DESCRIPTION
The previous implementation used a hardcoded user ID of 1, which was not present in the user's test database, causing the auto-login to fail silently.

This commit changes the logic to use a hardcoded email address (`admin@voluntarios.org`), as provided by the user, to find the user for auto-login. This is more robust and specific to the user's environment.