### PR TITLE
chore(security): Throw exception if auto-login user not found

### DIFF
--- a/src/EventSubscriber/DevAutoLoginSubscriber.php
+++ b/src/EventSubscriber/DevAutoLoginSubscriber.php
@@ -37,7 +37,7 @@ class DevAutoLoginSubscriber implements EventSubscriberInterface
         $user = $this->userRepository->findOneBy(['email' => self::DEFAULT_ADMIN_EMAIL]);
 
         if (!$user) {
-            return;
+            throw new \LogicException("Auto-login failed: User 'admin@voluntarios.org' not found in the database. Please ensure this user exists.");
         }
 
         $token = new UsernamePasswordToken($user, 'main', $user->getRoles());


### PR DESCRIPTION
The auto-login feature was failing silently when the specified user (`admin@voluntarios.org`) could not be found in the database, causing a confusing redirect to the login page.

This commit changes the behavior to throw a `LogicException` with a clear error message in this scenario. This will make it easier to diagnose the root cause if the feature still fails in the user's environment.