### PR TITLE
Fix(security): Allow admin role to access volunteer list

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -28,8 +28,9 @@ security:
                 target: app_login
 
     role_hierarchy:
+        ROLE_COORDINATOR: ROLE_USER
         ROLE_ADVISER: ROLE_USER
-        ROLE_ADMIN: ROLE_ADMIN
+        ROLE_ADMIN: [ROLE_COORDINATOR, ROLE_ADVISER]
 
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used

--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -164,7 +164,9 @@ class ServiceController extends AbstractController
     #[Route('/services/{id}/volunteers', name: 'app_service_get_volunteers', methods: ['GET'])]
     public function getVolunteers(Request $request, Service $service, VolunteerRepository $volunteerRepository, PaginatorInterface $paginator): JsonResponse
     {
-        $this->denyAccessUnlessGranted('ROLE_COORDINATOR');
+        if (!$this->isGranted('ROLE_COORDINATOR') && !$this->isGranted('ROLE_ADMIN')) {
+            throw $this->createAccessDeniedException('No tienes permiso para realizar esta acción.');
+        }
 
         $queryBuilder = $volunteerRepository->createQueryBuilder('v')
             ->leftJoin('v.assistanceConfirmations', 'ac', 'WITH', 'ac.service = :service')


### PR DESCRIPTION
The "Agregar respuestas" modal in the service edit page was failing to load volunteers for users with the admin role, showing an "Error al cargar voluntarios" message. This was caused by two issues:

1.  An incorrect role hierarchy in `config/packages/security.yaml` where `ROLE_ADMIN` did not inherit permissions from `ROLE_COORDINATOR`.
2.  The `getVolunteers` API endpoint in `ServiceController` only checked for `ROLE_COORDINATOR`.

This commit corrects the role hierarchy to ensure `ROLE_ADMIN` inherits from `ROLE_COORDINATOR`. It also updates the access control check in the controller to explicitly allow both roles, making the permission more robust and clear.