### PR TITLE
Fix volunteer search query and display specialization

### DIFF
--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -168,15 +168,15 @@ class ServiceController extends AbstractController
             throw $this->createAccessDeniedException('No tienes permiso para realizar esta acción.');
         }
 
-        $qb = $entityManager->createQueryBuilder();
-        $subQuery = $qb->select('IDENTITY(ac.volunteer)')
-            ->from(AssistanceConfirmation::class, 'ac')
-            ->where('ac.service = :service')
-            ->getDQL();
-
-        $queryBuilder = $volunteerRepository->createQueryBuilder('v');
-        $queryBuilder->where('v.status = :status')
-            ->andWhere($queryBuilder->expr()->notIn('v.id', $subQuery))
+        $queryBuilder = $volunteerRepository->createQueryBuilder('v')
+            ->leftJoin(
+                AssistanceConfirmation::class,
+                'ac',
+                'WITH',
+                'ac.volunteer = v.id AND ac.service = :service'
+            )
+            ->where('v.status = :status')
+            ->andWhere('ac.id IS NULL')
             ->setParameter('status', 'active')
             ->setParameter('service', $service);
 


### PR DESCRIPTION
This commit fixes a bug where the list of volunteers to add to a service was empty. The query logic in the `getVolunteers` method in `ServiceController.php` was incorrect.

The query has been re-implemented to use a `LEFT JOIN` with an `IS NULL` check, which is a more robust way to filter for volunteers who do not have an assistance confirmation for the given service.

This commit also includes previous changes:
- The pagination limit is now correctly handled using a request parameter.
- The volunteer's specialization is now included in the response and displayed in the UI, as per the user's request.