### PR TITLE
Fix: Unregistered volunteers not showing in modal

### DIFF
--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -173,7 +173,7 @@ class ServiceController extends AbstractController
                 AssistanceConfirmation::class,
                 'ac',
                 'WITH',
-                'ac.volunteer = v.id AND ac.service = :service'
+                'ac.volunteer = v AND ac.service = :service'
             )
             ->where('v.status = :status')
             ->andWhere('ac.id IS NULL')


### PR DESCRIPTION
The query to fetch volunteers not yet assigned to a service was incorrect. The LEFT JOIN condition compared the association field 'volunteer' with the volunteer's ID instead of the volunteer entity object. This change corrects the Doctrine query to properly filter and display the list of unassigned volunteers in the "Add Volunteers" modal.