### PR TITLE
fix: Add volunteer list modal to admin dashboard

### DIFF
--- a/templates/dashboard/admin_dashboard.html.twig
+++ b/templates/dashboard/admin_dashboard.html.twig
@@ -130,7 +130,7 @@
     <!-- Quick actions -->
     <div class="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
         <h3 class="text-lg font-semibold text-gray-900 mb-4">Acciones Rápidas</h3>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4" {{ stimulus_controller('modal') }}>
             <a href="{{ path('app_volunteer_new') }}" class="flex items-center gap-3 p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
                 <i data-lucide="users" class="w-5 h-5 text-blue-600"></i>
                 <span class="font-medium">Añadir Voluntario</span>
@@ -143,16 +143,15 @@
                 <i data-lucide="trending-up" class="w-5 h-5 text-purple-600"></i>
                 <span class="font-medium">Ver Estadísticas</span>
             </button>
-            <button id="show-volunteers-modal-btn" class="flex items-center gap-3 p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
+            <button
+                type="button"
+                class="flex items-center gap-3 p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+                data-action="click->modal#open"
+                data-modal-url-value="{{ path('app_volunteer_all') }}">
                 <i data-lucide="list" class="w-5 h-5 text-yellow-600"></i>
                 <span class="font-medium">Mostrar Voluntarios</span>
             </button>
         </div>
     </div>
 </div>
-{% endblock %}
-
-{% block javascripts %}
-    {{ parent() }}
-    <script src="{{ asset('js/volunteer_modal.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
- Creates a new API endpoint to fetch all volunteers (ID and name).
- Adds a 'Show Volunteers' button to the admin dashboard's quick actions.
- Implements a Stimulus controller to handle the modal logic, including fetching data and creating the modal dynamically.
- Registers the new Stimulus controller in `assets/controllers.json` to ensure it's loaded by the application.