### PR TITLE
feat: Add image, search, and pagination to volunteer modal

### DIFF
--- a/templates/dashboard/admin_dashboard.html.twig
+++ b/templates/dashboard/admin_dashboard.html.twig
@@ -157,92 +157,123 @@
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         const showModalBtn = document.getElementById('show-volunteers-btn');
+        let debounceTimer;
 
-        if (showModalBtn) {
-            showModalBtn.addEventListener('click', async () => {
-                const url = showModalBtn.dataset.url;
-                if (!url) {
-                    console.error('The URL for fetching volunteers is not defined in data-url attribute.');
-                    alert('No se pudo cargar la lista de voluntarios: URL no especificada.');
-                    return;
+        // Function to fetch and render volunteers
+        async function fetchAndRenderVolunteers(searchTerm = '', limit = 10) {
+            const baseUrl = showModalBtn.dataset.url;
+            const url = new URL(baseUrl, window.location.origin);
+            url.searchParams.append('search', searchTerm);
+            url.searchParams.append('limit', limit);
+
+            try {
+                const response = await fetch(url);
+                if (!response.ok) throw new Error('Network response was not ok');
+                const volunteers = await response.json();
+
+                const list = document.getElementById('volunteer-list-container');
+                if (!list) return;
+
+                list.innerHTML = ''; // Clear current list
+                if (volunteers.length > 0) {
+                    volunteers.forEach(v => {
+                        const listItem = document.createElement('li');
+                        listItem.className = 'p-2 border-b border-gray-200 flex items-center';
+
+                        const img = document.createElement('img');
+                        img.src = v.profilePicture ? `/uploads/profile_pictures/${v.profilePicture}` : 'https://via.placeholder.com/40';
+                        img.alt = v.name;
+                        img.className = 'w-10 h-10 rounded-full mr-3 object-cover';
+
+                        const checkbox = document.createElement('input');
+                        checkbox.type = 'checkbox';
+                        checkbox.id = `volunteer-${v.id}`;
+                        checkbox.value = v.id;
+                        checkbox.className = 'mr-3 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500';
+
+                        const label = document.createElement('label');
+                        label.htmlFor = `volunteer-${v.id}`;
+                        label.textContent = v.name;
+
+                        listItem.appendChild(img);
+                        listItem.appendChild(checkbox);
+                        listItem.appendChild(label);
+                        list.appendChild(listItem);
+                    });
+                } else {
+                    list.innerHTML = '<p>No se encontraron voluntarios.</p>';
                 }
-                try {
-                    const response = await fetch(url);
-                    if (!response.ok) {
-                        throw new Error('Network response was not ok');
-                    }
-                    const volunteers = await response.json();
-                    createModal(volunteers);
-                } catch (error) {
-                    console.error('Error fetching volunteers:', error);
-                    alert('No se pudo cargar la lista de voluntarios.');
-                }
-            });
+            } catch (error) {
+                console.error('Error fetching volunteers:', error);
+                const list = document.getElementById('volunteer-list-container');
+                if(list) list.innerHTML = '<p>Error al cargar los voluntarios.</p>';
+            }
         }
 
-        function createModal(volunteers) {
+        // Function to create the modal structure
+        function createModal() {
             const existingModal = document.getElementById('volunteer-list-modal');
-            if (existingModal) {
-                existingModal.remove();
-            }
+            if (existingModal) existingModal.remove();
 
             const modal = document.createElement('div');
             modal.id = 'volunteer-list-modal';
             modal.className = 'fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full flex items-center justify-center';
             modal.style.zIndex = '1050';
 
-            const modalContent = document.createElement('div');
-            modalContent.className = 'relative mx-auto p-5 border w-full max-w-md shadow-lg rounded-md bg-white';
+            modal.innerHTML = `
+                <div class="relative mx-auto p-5 border w-full max-w-md shadow-lg rounded-md bg-white">
+                    <div class="flex justify-between items-center pb-3 border-b">
+                        <h3 class="text-lg font-medium text-gray-900">Lista de Voluntarios</h3>
+                        <button id="close-volunteer-modal-btn" type="button" class="text-black close-modal text-2xl leading-none hover:text-gray-700">&times;</button>
+                    </div>
+                    <div class="py-3 flex justify-between items-center">
+                        <input type="text" id="volunteer-search-input" placeholder="Buscar por nombre..." class="w-full md:w-1/2 p-2 border border-gray-300 rounded-md">
+                        <select id="volunteer-limit-select" class="p-2 border border-gray-300 rounded-md">
+                            <option value="10">10 por página</option>
+                            <option value="25" selected>25 por página</option>
+                            <option value="50">50 por página</option>
+                            <option value="100">100 por página</option>
+                        </select>
+                    </div>
+                    <ul id="volunteer-list-container" class="space-y-2 max-h-80 overflow-y-auto py-3">
+                        <!-- Volunteer list will be rendered here -->
+                    </ul>
+                </div>
+            `;
 
-            const modalHeader = document.createElement('div');
-            modalHeader.className = 'flex justify-between items-center pb-3 border-b';
-            modalHeader.innerHTML = '<h3 class="text-lg font-medium text-gray-900">Lista de Voluntarios</h3>';
-
-            const closeButton = document.createElement('button');
-            closeButton.innerHTML = '&times;';
-            closeButton.className = 'text-black close-modal text-2xl leading-none hover:text-gray-700';
-
-            modalHeader.appendChild(closeButton);
-            modalContent.appendChild(modalHeader);
-
-            const list = document.createElement('ul');
-            list.className = 'space-y-2 max-h-80 overflow-y-auto py-3';
-
-            if (volunteers.length > 0) {
-                volunteers.forEach(v => {
-                    const listItem = document.createElement('li');
-                    listItem.className = 'p-2 border-b border-gray-200 flex items-center';
-
-                    const checkbox = document.createElement('input');
-                    checkbox.type = 'checkbox';
-                    checkbox.id = `volunteer-${v.id}`;
-                    checkbox.value = v.id;
-                    checkbox.className = 'mr-3 h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500';
-
-                    const label = document.createElement('label');
-                    label.htmlFor = `volunteer-${v.id}`;
-                    label.textContent = v.name;
-
-                    listItem.appendChild(checkbox);
-                    listItem.appendChild(label);
-                    list.appendChild(listItem);
-                });
-            } else {
-                const noVolunteers = document.createElement('p');
-                noVolunteers.textContent = 'No hay voluntarios para mostrar.';
-                list.appendChild(noVolunteers);
-            }
-
-            modalContent.appendChild(list);
-            modal.appendChild(modalContent);
             document.body.appendChild(modal);
+
+            // Add event listeners for the new controls
+            const searchInput = document.getElementById('volunteer-search-input');
+            const limitSelect = document.getElementById('volunteer-limit-select');
+            const closeButton = document.getElementById('close-volunteer-modal-btn');
+
+            searchInput.addEventListener('input', () => {
+                clearTimeout(debounceTimer);
+                debounceTimer = setTimeout(() => {
+                    fetchAndRenderVolunteers(searchInput.value, limitSelect.value);
+                }, 300);
+            });
+
+            limitSelect.addEventListener('change', () => {
+                fetchAndRenderVolunteers(searchInput.value, limitSelect.value);
+            });
 
             const closeModal = () => modal.remove();
             closeButton.onclick = closeModal;
             modal.addEventListener('click', (e) => {
-                if (e.target === modal) {
-                    closeModal();
-                }
+                if (e.target === modal) closeModal();
+            });
+        }
+
+        // Main event listener for the button
+        if (showModalBtn) {
+            showModalBtn.addEventListener('click', () => {
+                createModal();
+                // Initial fetch
+                const searchInput = document.getElementById('volunteer-search-input');
+                const limitSelect = document.getElementById('volunteer-limit-select');
+                fetchAndRenderVolunteers(searchInput.value, limitSelect.value);
             });
         }
     });


### PR DESCRIPTION
- Updates the volunteer API endpoint to support search and pagination, and to include the profile picture URL.
- Enhances the volunteer list modal with new controls:
  - A search input that filters the list as the user types (with debounce).
  - A dropdown to control the number of items per page (10, 25, 50, 100).
- The volunteer list now displays the profile picture for each volunteer.
- All JavaScript logic is embedded directly in the Twig template to ensure reliability.