### PR TITLE
fix(service): Repair volunteer attendance modal

### DIFF
--- a/assets/controllers/service_form_controller.js
+++ b/assets/controllers/service_form_controller.js
@@ -151,11 +151,7 @@ export default class extends Controller {
 
         const nameSpan = document.createElement('span');
         nameSpan.className = 'ml-3 font-medium text-gray-700';
-        let volunteerText = volunteer.name;
-        if (volunteer.specialization) {
-            volunteerText += ` - ${volunteer.specialization}:`;
-        }
-        nameSpan.textContent = volunteerText;
+        nameSpan.textContent = volunteer.name;
 
         row.appendChild(checkbox);
         row.appendChild(nameSpan);

--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -168,8 +168,8 @@ class ServiceController extends AbstractController
             throw $this->createAccessDeniedException('No tienes permiso para realizar esta acción.');
         }
 
-        $queryBuilder = $volunteerRepository->createQueryBuilder('v')
-            ->leftJoin(
+        $queryBuilder = $volunteerRepository->createQueryBuilder('v');
+        $queryBuilder->leftJoin(
                 AssistanceConfirmation::class,
                 'ac',
                 'WITH',


### PR DESCRIPTION
- Fixes a critical bug in `ServiceController::getVolunteers` that prevented the volunteer list from loading. The query was using an incorrect string for the volunteer status instead of the correct entity constant.
- Sets the default pagination in the modal to 10 records, as requested.
- Cleans up the volunteer name display in the modal to show only the full name, removing the specialization.