### PR TITLE
fix(service): Correct pagination limit in volunteer modal

### DIFF
--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -194,10 +194,11 @@ class ServiceController extends AbstractController
 
         $query = $queryBuilder->getQuery();
 
+        $limit = $request->query->getInt('limit', 10);
         $pagination = $paginator->paginate(
             $query,
             $request->query->getInt('page', 1),
-            $request->query->getInt('limit', 10)
+            $limit
         );
 
         $data = [


### PR DESCRIPTION
- Ensures that the `limit` parameter from the request is correctly passed to the KNP Paginator bundle in the `getVolunteers` action.
- This resolves an issue where the modal would not display the correct number of volunteers according to the pagination selection.