### PR TITLE
feat: Add button to remove volunteer from attendance list

### DIFF
--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -241,6 +241,20 @@ class ServiceController extends AbstractController
         return new JsonResponse(['success' => true, 'message' => 'Asistencia actualizada correctamente.']);
     }
 
+    #[Route('/assistance-confirmation/{id}/remove', name: 'app_assistance_confirmation_remove', methods: ['POST'])]
+    public function removeAttendant(Request $request, AssistanceConfirmation $confirmation, EntityManagerInterface $entityManager): Response
+    {
+        $this->denyAccessUnlessGranted('ROLE_COORDINATOR');
+
+        if ($this->isCsrfTokenValid('delete'.$confirmation->getId(), $request->request->get('_token'))) {
+            $confirmation->setHasAttended(false);
+            $entityManager->flush();
+            $this->addFlash('success', 'Voluntario eliminado de la lista de asistentes.');
+        }
+
+        return $this->redirectToRoute('app_service_edit', ['id' => $confirmation->getService()->getId(), '_fragment' => 'asistencias']);
+    }
+
     #[Route('/servicio/{id}/asistir', name: 'app_service_attend', methods: ['GET'])]
     public function attend(?Service $service, EntityManagerInterface $entityManager, \Symfony\Bundle\SecurityBundle\Security $security, \App\Repository\AssistanceConfirmationRepository $assistanceConfirmationRepository): Response
     {

--- a/templates/service/edit_service.html.twig
+++ b/templates/service/edit_service.html.twig
@@ -248,7 +248,15 @@
                     </h4>
                     <ul class="list-group space-y-2">
                         {% for confirmation in service.assistanceConfirmations|filter(c => c.isHasAttended() == true) %}
-                            <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm">{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</li>
+                            <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm flex justify-between items-center">
+                                <span>{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</span>
+                                <form method="post" action="{{ path('app_assistance_confirmation_remove', {'id': confirmation.id}) }}" onsubmit="return confirm('¿Estás seguro de que quieres eliminar a este voluntario de la lista de asistentes?');">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ confirmation.id) }}">
+                                    <button type="submit" class="text-red-500 hover:text-red-700">
+                                        <i data-lucide="trash-2" class="h-5 w-5"></i>
+                                    </button>
+                                </form>
+                            </li>
                         {% else %}
                             <li class="list-group-item text-gray-500 italic">Nadie asiste todavía.</li>
                         {% endfor %}


### PR DESCRIPTION
This commit introduces a new feature that allows coordinators to remove a volunteer from the list of attendees for a specific service.

- A new controller action `removeAttendant` has been added to `ServiceController.php` to handle the removal logic. This action sets the `hasAttended` flag of the `AssistanceConfirmation` entity to `false`, effectively moving the volunteer to the "not attending" list while preserving the confirmation record.
- The `edit_service.html.twig` template has been updated to include a delete button next to each attendee's name. The button is part of a form that submits a POST request to the new endpoint.
- CSRF protection is included for the new form to enhance security.
- A JavaScript confirmation dialog is used to prevent accidental removals.