### PR TITLE
feat: Add timestamp to attendance confirmation and change delete beha…

### DIFF
--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -247,9 +247,9 @@ class ServiceController extends AbstractController
         $this->denyAccessUnlessGranted('ROLE_COORDINATOR');
 
         if ($this->isCsrfTokenValid('delete'.$confirmation->getId(), $request->request->get('_token'))) {
-            $confirmation->setHasAttended(false);
+            $entityManager->remove($confirmation);
             $entityManager->flush();
-            $this->addFlash('success', 'Voluntario eliminado de la lista de asistentes.');
+            $this->addFlash('success', 'La confirmación de asistencia ha sido eliminada.');
         }
 
         return $this->redirectToRoute('app_service_edit', ['id' => $confirmation->getService()->getId(), '_fragment' => 'asistencias']);

--- a/src/Entity/AssistanceConfirmation.php
+++ b/src/Entity/AssistanceConfirmation.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use App\Repository\AssistanceConfirmationRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 
 #[ORM\Entity(repositoryClass: AssistanceConfirmationRepository::class)]
 class AssistanceConfirmation
@@ -23,6 +24,14 @@ class AssistanceConfirmation
     #[ORM\ManyToOne(inversedBy: 'assistanceConfirmations')]
     #[ORM\JoinColumn(nullable: false)]
     private ?Volunteer $volunteer = null;
+
+    #[Gedmo\Timestampable(on: 'create')]
+    #[ORM\Column(type: 'datetime')]
+    private $createdAt;
+
+    #[Gedmo\Timestampable(on: 'update')]
+    #[ORM\Column(type: 'datetime')]
+    private $updatedAt;
 
     public function getId(): ?int
     {
@@ -63,5 +72,15 @@ class AssistanceConfirmation
         $this->volunteer = $volunteer;
 
         return $this;
+    }
+
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt()
+    {
+        return $this->updatedAt;
     }
 }

--- a/templates/service/edit_service.html.twig
+++ b/templates/service/edit_service.html.twig
@@ -249,8 +249,11 @@
                     <ul class="list-group space-y-2">
                         {% for confirmation in service.assistanceConfirmations|filter(c => c.isHasAttended() == true) %}
                             <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm flex justify-between items-center">
-                                <span>{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</span>
-                                <form method="post" action="{{ path('app_assistance_confirmation_remove', {'id': confirmation.id}) }}" onsubmit="return confirm('¿Estás seguro de que quieres eliminar a este voluntario de la lista de asistentes?');">
+                                <span>
+                                    {{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}
+                                    <small class="text-gray-500">({{ confirmation.updatedAt|date('d/m/Y H:i') }})</small>
+                                </span>
+                                <form method="post" action="{{ path('app_assistance_confirmation_remove', {'id': confirmation.id}) }}" onsubmit="return confirm('¿Estás seguro de que quieres eliminar la confirmación de asistencia de este voluntario? Esta acción no se puede deshacer.');">
                                     <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ confirmation.id) }}">
                                     <button type="submit" class="text-red-500 hover:text-red-700">
                                         <i data-lucide="trash-2" class="h-5 w-5"></i>
@@ -270,7 +273,10 @@
                     </h4>
                     <ul class="list-group space-y-2">
                         {% for confirmation in service.assistanceConfirmations|filter(c => c.isHasAttended() == false) %}
-                            <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm">{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</li>
+                            <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm">
+                                {{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}
+                                <small class="text-gray-500">({{ confirmation.updatedAt|date('d/m/Y H:i') }})</small>
+                            </li>
                         {% else %}
                             <li class="list-group-item text-gray-500 italic">Nadie ha cancelado.</li>
                         {% endfor %}


### PR DESCRIPTION
…vior

This commit introduces two new features based on user feedback:

1.  **Display Timestamp for Attendance Confirmation:**
    - The `AssistanceConfirmation` entity has been updated to include `createdAt` and `updatedAt` fields using Gedmo's Timestampable extension.
    - The `edit_service.html.twig` template has been modified to display the `updatedAt` timestamp next to each volunteer's name in both the "attending" and "not attending" lists. This provides clarity on when the confirmation was last updated.

2.  **Change Delete Button Behavior:**
    - The `removeAttendant` action in `ServiceController.php` has been modified to permanently delete the `AssistanceConfirmation` entity from the database, instead of just marking it as "not attending".
    - The confirmation message for the delete button in `edit_service.html.twig` has been updated to reflect this permanent action.