### PR TITLE
feat: Add placeholder clock-in button to attendance lists

### DIFF
--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -241,6 +241,20 @@ class ServiceController extends AbstractController
         return new JsonResponse(['success' => true, 'message' => 'Asistencia actualizada correctamente.']);
     }
 
+    #[Route('/assistance-confirmation/{id}/remove', name: 'app_assistance_confirmation_remove', methods: ['POST'])]
+    public function removeAttendant(Request $request, AssistanceConfirmation $confirmation, EntityManagerInterface $entityManager): Response
+    {
+        $this->denyAccessUnlessGranted('ROLE_COORDINATOR');
+
+        if ($this->isCsrfTokenValid('delete'.$confirmation->getId(), $request->request->get('_token'))) {
+            $entityManager->remove($confirmation);
+            $entityManager->flush();
+            $this->addFlash('success', 'La confirmación de asistencia ha sido eliminada.');
+        }
+
+        return $this->redirectToRoute('app_service_edit', ['id' => $confirmation->getService()->getId(), '_fragment' => 'asistencias']);
+    }
+
     #[Route('/servicio/{id}/asistir', name: 'app_service_attend', methods: ['GET'])]
     public function attend(?Service $service, EntityManagerInterface $entityManager, \Symfony\Bundle\SecurityBundle\Security $security, \App\Repository\AssistanceConfirmationRepository $assistanceConfirmationRepository): Response
     {

--- a/src/Entity/AssistanceConfirmation.php
+++ b/src/Entity/AssistanceConfirmation.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use App\Repository\AssistanceConfirmationRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 
 #[ORM\Entity(repositoryClass: AssistanceConfirmationRepository::class)]
 class AssistanceConfirmation
@@ -23,6 +24,14 @@ class AssistanceConfirmation
     #[ORM\ManyToOne(inversedBy: 'assistanceConfirmations')]
     #[ORM\JoinColumn(nullable: false)]
     private ?Volunteer $volunteer = null;
+
+    #[Gedmo\Timestampable(on: 'create')]
+    #[ORM\Column(type: 'datetime')]
+    private $createdAt;
+
+    #[Gedmo\Timestampable(on: 'update')]
+    #[ORM\Column(type: 'datetime')]
+    private $updatedAt;
 
     public function getId(): ?int
     {
@@ -63,5 +72,15 @@ class AssistanceConfirmation
         $this->volunteer = $volunteer;
 
         return $this;
+    }
+
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt()
+    {
+        return $this->updatedAt;
     }
 }

--- a/templates/service/edit_service.html.twig
+++ b/templates/service/edit_service.html.twig
@@ -248,7 +248,23 @@
                     </h4>
                     <ul class="list-group space-y-2">
                         {% for confirmation in service.assistanceConfirmations|filter(c => c.isHasAttended() == true) %}
-                            <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm">{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</li>
+                            <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm flex justify-between items-center">
+                                <span>
+                                    {{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}
+                                    <small class="text-gray-500">({{ confirmation.updatedAt|date('d/m/Y H:i') }})</small>
+                                </span>
+                                <div class="flex items-center space-x-2">
+                                    <button type="button" class="text-green-500 hover:text-green-700" title="Fichar">
+                                        <i data-lucide="check-square" class="h-5 w-5"></i>
+                                    </button>
+                                    <form method="post" action="{{ path('app_assistance_confirmation_remove', {'id': confirmation.id}) }}" onsubmit="return confirm('¿Estás seguro de que quieres eliminar la confirmación de asistencia de este voluntario? Esta acción no se puede deshacer.');">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ confirmation.id) }}">
+                                        <button type="submit" class="text-red-500 hover:text-red-700">
+                                            <i data-lucide="trash-2" class="h-5 w-5"></i>
+                                        </button>
+                                    </form>
+                                </div>
+                            </li>
                         {% else %}
                             <li class="list-group-item text-gray-500 italic">Nadie asiste todavía.</li>
                         {% endfor %}
@@ -262,7 +278,23 @@
                     </h4>
                     <ul class="list-group space-y-2">
                         {% for confirmation in service.assistanceConfirmations|filter(c => c.isHasAttended() == false) %}
-                            <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm">{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</li>
+                            <li class="list-group-item bg-gray-50 p-3 rounded-lg shadow-sm flex justify-between items-center">
+                                <span>
+                                    {{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}
+                                    <small class="text-gray-500">({{ confirmation.updatedAt|date('d/m/Y H:i') }})</small>
+                                </span>
+                                <div class="flex items-center space-x-2">
+                                    <button type="button" class="text-green-500 hover:text-green-700" title="Fichar">
+                                        <i data-lucide="check-square" class="h-5 w-5"></i>
+                                    </button>
+                                    <form method="post" action="{{ path('app_assistance_confirmation_remove', {'id': confirmation.id}) }}" onsubmit="return confirm('¿Estás seguro de que quieres eliminar la confirmación de asistencia de este voluntario? Esta acción no se puede deshacer.');">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ confirmation.id) }}">
+                                        <button type="submit" class="text-red-500 hover:text-red-700">
+                                            <i data-lucide="trash-2" class="h-5 w-5"></i>
+                                        </button>
+                                    </form>
+                                </div>
+                            </li>
                         {% else %}
                             <li class="list-group-item text-gray-500 italic">Nadie ha cancelado.</li>
                         {% endfor %}


### PR DESCRIPTION
This commit adds a non-functional 'clock-in' button to the attendance lists on the service edit page. This button is added to the left of the delete button for each volunteer in both the 'Asisten' and 'No Asisten' lists, serving as a placeholder for future functionality.