### PR TITLE
feat: Implement 'Fichar todos' modal

### DIFF
--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -466,4 +466,15 @@ class Service
 
         return $this;
     }
+
+    /**
+     * @return Volunteer[]
+     */
+    public function getAttendingVolunteers(): array
+    {
+        return $this->assistanceConfirmations
+            ->filter(fn(AssistanceConfirmation $c) => $c->isHasAttended() === true)
+            ->map(fn(AssistanceConfirmation $c) => $c->getVolunteer())
+            ->getValues();
+    }
 }

--- a/templates/service/edit_service.html.twig
+++ b/templates/service/edit_service.html.twig
@@ -235,7 +235,7 @@
                         <i data-lucide="user-plus" class="mr-2 h-5 w-5"></i> Añadir voluntarios
                     </button>
                 </div>
-                <button type="button" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center" data-action="click->service-form#clockInAll">
+                <button type="button" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center" data-action="click->service-form#openClockInModal">
                     <i data-lucide="check-square" class="mr-2 h-5 w-5"></i> Fichar todos
                 </button>
             </div>
@@ -339,6 +339,52 @@
 
             <div class="flex justify-end space-x-4 border-t pt-4">
                 <button type="button" data-action="click->service-form#saveAttendance" class="px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700">Aceptar</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Clock-in All Modal -->
+    <div class="hidden fixed inset-0 bg-gray-800 bg-opacity-60 flex items-center justify-center z-50" data-service-form-target="clockInModal">
+        <div class="modal-content bg-white rounded-2xl shadow-2xl p-8 max-w-3xl w-full mx-4">
+            <div class="flex justify-between items-center mb-6 border-b pb-4">
+                <h3 class="text-2xl font-bold text-gray-900">Fichar a todos</h3>
+                <button type="button" data-action="click->service-form#closeClockInModal" class="text-gray-400 hover:text-gray-600">
+                    <i data-lucide="x" class="h-6 w-6"></i>
+                </button>
+            </div>
+
+            <div class="grid grid-cols-2 gap-6 mb-6">
+                <div>
+                    <label for="clockin-start-date" class="block text-sm font-medium text-gray-700 mb-1">Fecha Entrada <span class="text-red-500">*</span></label>
+                    <input type="date" data-service-form-target="clockInStartDate" id="clockin-start-date" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm">
+                </div>
+                <div>
+                    <label for="clockin-start-time" class="block text-sm font-medium text-gray-700 mb-1">Hora Entrada <span class="text-red-500">*</span></label>
+                    <input type="time" data-service-form-target="clockInStartTime" id="clockin-start-time" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm">
+                </div>
+                <div>
+                    <label for="clockin-end-date" class="block text-sm font-medium text-gray-700 mb-1">Fecha salida <span class="text-red-500">*</span></label>
+                    <input type="date" data-service-form-target="clockInEndDate" id="clockin-end-date" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm">
+                </div>
+                <div>
+                    <label for="clockin-end-time" class="block text-sm font-medium text-gray-700 mb-1">Hora salida <span class="text-red-500">*</span></label>
+                    <input type="time" data-service-form-target="clockInEndTime" id="clockin-end-time" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm">
+                </div>
+            </div>
+
+            <h4 class="text-lg font-semibold mb-3 text-gray-800">Personal</h4>
+            <div class="border rounded-lg p-2 mb-4" style="min-height: 150px; max-height: 30vh; overflow-y: auto;">
+                <div class="flex items-center p-2 border-b">
+                    <input type="checkbox" data-action="click->service-form#toggleAllVolunteers" class="form-checkbox h-5 w-5 text-blue-600 rounded border-gray-300">
+                    <span class="ml-3 font-semibold text-gray-700">Todos</span>
+                </div>
+                <div data-service-form-target="clockInVolunteerList" class="space-y-1">
+                    <!-- Volunteer list for clock-in will be populated here -->
+                </div>
+            </div>
+
+            <div class="flex justify-end space-x-4 border-t pt-4">
+                <button type="button" data-action="click->service-form#saveClockIn" class="px-6 py-3 bg-green-600 text-white font-semibold rounded-lg shadow-md hover:bg-green-700">Aceptar</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This commit implements the 'Fichar todos' (Clock-in all) functionality.

- Adds a modal to the 'Editar Servicio' page that is displayed when the 'Fichar todos' button is clicked.
- The modal allows setting a start and end date/time for multiple volunteers at once.
- It fetches and displays the list of volunteers who have confirmed their attendance.
- Includes a 'Select All' checkbox for convenience.
- The Stimulus controller `service_form_controller.js` is updated to handle the modal's logic.
- A new backend endpoint `/services/{id}/clock-in-all` is created in `ServiceController.php` to process and save the clock-in data.
- A helper method `getAttendingVolunteers` is added to the `Service` entity.