### PR TITLE
Refactor service edit page to attendance confirmation view

### DIFF
--- a/templates/service/edit_service.html.twig
+++ b/templates/service/edit_service.html.twig
@@ -252,9 +252,7 @@
                                 {% set fichaje = fichajes[confirmation.volunteer.id] ?? null %}
                                 <div class="flex items-center justify-between">
                                     <span class="font-bold">{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</span>
-                                    {% if fichaje %}
-                                        <span class="text-xs text-gray-500">{{ fichaje.startTime|date('d/m/Y H:i') }}</span>
-                                    {% endif %}
+                                    <small class="text-gray-500">({{ confirmation.updatedAt|date('d/m/Y H:i') }})</small>
                                 </div>
                                 <div class="mt-2">
                                     {% if fichaje %}
@@ -282,6 +280,10 @@
                                             <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
                                             Pendiente de fichar
                                         </span>
+                                        <p class="text-sm text-gray-600 mt-1">
+                                            <strong>Entrada:</strong> No fichado. -
+                                            <strong>Salida:</strong> No fichado.
+                                        </p>
                                     {% endif %}
                                 </div>
                                 <div class="flex justify-end mt-2">


### PR DESCRIPTION
- Changed the title and heading of the service edit page from "Editar Servicio" to "Confirmación de Asistencia".
- Modified the `ServiceController` to fetch and provide detailed check-in/out (`fichaje`) data to the template.
- Updated the "Asisten" (Attendees) list to display detailed information for each volunteer, including check-in/out times, completion status, and confirmation time, as per the user's request.
- Added a more detailed status for volunteers who are pending check-in.