### PR TITLE
feat: Implement reserve list and automatic promotion

### DIFF
--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -76,6 +76,7 @@ class Service
     private ?string $requester = null;
 
     #[ORM\OneToMany(mappedBy: 'service', targetEntity: AssistanceConfirmation::class, orphanRemoval: true)]
+    #[ORM\OrderBy(['createdAt' => 'ASC'])]
     private Collection $assistanceConfirmations;
 
     #[ORM\Column(length: 255, nullable: true)]


### PR DESCRIPTION
- Modified `AssistanceConfirmation` entity to support 'attending', 'not_attending', and 'reserved' statuses.
- Updated `ServiceController` to handle the logic for the reserve list. If a service has a `maxAttendees` limit, volunteers who confirm after the limit is reached are placed on the reserve list.
- Implemented automatic promotion of the first volunteer from the reserve list when a spot on the attending list becomes available.
- Updated the service edit page to display three lists: Attending, Reserve, and Not Attending.
- Added delete buttons to the Reserve and Not Attending lists.
- The attendance lists are now sorted by the confirmation time.