### PR TITLE
This commit introduces a comprehensive overhaul of the service attend…

### DIFF
--- a/migrations/Version20250923034530.php
+++ b/migrations/Version20250923034530.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250923034530 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Creates the Fichaje table for individual clock-in/out records.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE fichaje (id INT AUTO_INCREMENT NOT NULL, volunteer_service_id INT NOT NULL, start_time DATETIME NOT NULL, end_time DATETIME DEFAULT NULL, notes LONGTEXT DEFAULT NULL, INDEX IDX_3942A3A4A8A653A (volunteer_service_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE fichaje ADD CONSTRAINT FK_3942A3A4A8A653A FOREIGN KEY (volunteer_service_id) REFERENCES volunteer_service (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE fichaje DROP FOREIGN KEY FK_3942A3A4A8A653A');
+        $this->addSql('DROP TABLE fichaje');
+    }
+}

--- a/migrations/Version20250923035300.php
+++ b/migrations/Version20250923035300.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250923035300 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Removes obsolete startTime, endTime, duration, and notes columns from the volunteer_service table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE volunteer_service DROP start_time, DROP end_time, DROP notes, DROP duration');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE volunteer_service ADD start_time DATETIME DEFAULT NULL, ADD end_time DATETIME DEFAULT NULL, ADD notes LONGTEXT DEFAULT NULL, ADD duration INT DEFAULT NULL');
+    }
+}

--- a/src/Controller/FichajeController.php
+++ b/src/Controller/FichajeController.php
@@ -5,6 +5,8 @@ namespace App\Controller;
 use App\Entity\Service;
 use App\Entity\VolunteerService;
 use App\Repository\VolunteerRepository;
+use App\Entity\Fichaje;
+use App\Repository\FichajeRepository;
 use App\Repository\VolunteerServiceRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -39,20 +41,36 @@ class FichajeController extends AbstractController
         $duration = $endTime->getTimestamp() - $startTime->getTimestamp();
         $durationInMinutes = round($duration / 60);
 
+        // --- NEW CLEANUP LOGIC ---
+        // First, remove all existing fichaje records for the entire service.
+        $allVolunteerServices = $service->getVolunteerServices();
+        foreach ($allVolunteerServices as $vs) {
+            foreach ($vs->getFichajes() as $fichaje) {
+                $entityManager->remove($fichaje);
+            }
+        }
+        // --- END NEW CLEANUP LOGIC ---
+
         foreach ($volunteerIds as $volunteerId) {
             $volunteer = $volunteerRepository->find($volunteerId);
             if ($volunteer) {
                 $volunteerService = $volunteerServiceRepository->findOneBy(['volunteer' => $volunteer, 'service' => $service]);
                 if (!$volunteerService) {
+                    // This case should ideally not be hit if volunteer is in the list,
+                    // but we handle it for robustness.
                     $volunteerService = new VolunteerService();
                     $volunteerService->setVolunteer($volunteer);
                     $volunteerService->setService($service);
                     $entityManager->persist($volunteerService);
                 }
 
-                $volunteerService->setStartTime($startTime);
-                $volunteerService->setEndTime($endTime);
-                $volunteerService->setDuration($durationInMinutes);
+                // Create a new Fichaje record with the mass clock-in/out times
+                $fichaje = new Fichaje();
+                $fichaje->setVolunteerService($volunteerService);
+                $fichaje->setStartTime($startTime);
+                $fichaje->setEndTime($endTime);
+
+                $entityManager->persist($fichaje);
             }
         }
 
@@ -61,5 +79,53 @@ class FichajeController extends AbstractController
         $this->addFlash('success', 'Fichaje guardado correctamente.');
 
         return $this->redirectToRoute('app_service_edit', ['id' => $service->getId(), '_fragment' => 'asistencias']);
+    }
+
+    #[Route('/volunteer_service/{id}/clockin', name: 'app_fichaje_clockin', methods: ['POST'])]
+    public function clockIn(Request $request, VolunteerService $volunteerService, EntityManagerInterface $entityManager, FichajeRepository $fichajeRepository): Response
+    {
+        $openFichaje = $fichajeRepository->findOpenFichaje($volunteerService);
+
+        if ($openFichaje) {
+            $this->addFlash('error', 'Este voluntario ya tiene un fichaje de entrada abierto.');
+            return $this->redirectToRoute('app_service_edit', ['id' => $volunteerService->getService()->getId(), '_fragment' => 'asistencias']);
+        }
+
+        $fichaje = new Fichaje();
+        $fichaje->setVolunteerService($volunteerService);
+        $fichaje->setStartTime(new \DateTime());
+        $fichaje->setNotes($request->request->get('notes'));
+
+        $entityManager->persist($fichaje);
+        $entityManager->flush();
+
+        $this->addFlash('success', 'Entrada registrada correctamente.');
+
+        return $this->redirectToRoute('app_service_edit', ['id' => $volunteerService->getService()->getId(), '_fragment' => 'asistencias']);
+    }
+
+    #[Route('/volunteer_service/{id}/clockout', name: 'app_fichaje_clockout', methods: ['POST'])]
+    public function clockOut(Request $request, VolunteerService $volunteerService, EntityManagerInterface $entityManager, FichajeRepository $fichajeRepository): Response
+    {
+        $openFichaje = $fichajeRepository->findOpenFichaje($volunteerService);
+
+        if (!$openFichaje) {
+            $this->addFlash('error', 'No se encontró un fichaje de entrada abierto para este voluntario.');
+            return $this->redirectToRoute('app_service_edit', ['id' => $volunteerService->getService()->getId(), '_fragment' => 'asistencias']);
+        }
+
+        $openFichaje->setEndTime(new \DateTime());
+        $openFichaje->setNotes($request->request->get('notes'));
+
+        if ($openFichaje->getEndTime() < $openFichaje->getStartTime()) {
+            $this->addFlash('error', 'La hora de salida no puede ser anterior a la hora de entrada.');
+            return $this->redirectToRoute('app_service_edit', ['id' => $volunteerService->getService()->getId(), '_fragment' => 'asistencias']);
+        }
+
+        $entityManager->flush();
+
+        $this->addFlash('success', 'Salida registrada correctamente.');
+
+        return $this->redirectToRoute('app_service_edit', ['id' => $volunteerService->getService()->getId(), '_fragment' => 'asistencias']);
     }
 }

--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -24,12 +24,15 @@ class ReportController extends AbstractController
         $data = [];
 
         foreach ($volunteerServices as $volunteerService) {
+            $firstFichaje = $volunteerService->getFichajes()->first();
+            $lastFichaje = $volunteerService->getFichajes()->last();
+
             $data[] = [
                 'service' => $volunteerService->getService()->getTitle(),
                 'date' => $volunteerService->getService()->getDate()->format('d/m/Y'),
-                'startTime' => $volunteerService->getStartTime()->format('H:i'),
-                'endTime' => $volunteerService->getEndTime()->format('H:i'),
-                'duration' => $volunteerService->getDuration(),
+                'startTime' => $firstFichaje ? $firstFichaje->getStartTime()->format('H:i') : 'N/A',
+                'endTime' => $lastFichaje && $lastFichaje->getEndTime() ? $lastFichaje->getEndTime()->format('H:i') : 'N/A',
+                'duration' => $volunteerService->calculateTotalDuration(),
             ];
         }
 

--- a/src/Entity/Fichaje.php
+++ b/src/Entity/Fichaje.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\FichajeRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: FichajeRepository::class)]
+class Fichaje
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(inversedBy: 'fichajes')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?VolunteerService $volunteerService = null;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
+    private ?\DateTimeInterface $startTime = null;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    private ?\DateTimeInterface $endTime = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $notes = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getVolunteerService(): ?VolunteerService
+    {
+        return $this->volunteerService;
+    }
+
+    public function setVolunteerService(?VolunteerService $volunteerService): static
+    {
+        $this->volunteerService = $volunteerService;
+
+        return $this;
+    }
+
+    public function getStartTime(): ?\DateTimeInterface
+    {
+        return $this->startTime;
+    }
+
+    public function setStartTime(\DateTimeInterface $startTime): static
+    {
+        $this->startTime = $startTime;
+
+        return $this;
+    }
+
+    public function getEndTime(): ?\DateTimeInterface
+    {
+        return $this->endTime;
+    }
+
+    public function setEndTime(?\DateTimeInterface $endTime): static
+    {
+        $this->endTime = $endTime;
+
+        return $this;
+    }
+
+    public function getNotes(): ?string
+    {
+        return $this->notes;
+    }
+
+    public function setNotes(?string $notes): static
+    {
+        $this->notes = $notes;
+
+        return $this;
+    }
+}

--- a/src/Entity/Volunteer.php
+++ b/src/Entity/Volunteer.php
@@ -569,4 +569,14 @@ class Volunteer
 
         return $this;
     }
+
+    public function getVolunteerServiceForService(Service $service): ?VolunteerService
+    {
+        foreach ($this->volunteerServices as $vs) {
+            if ($vs->getService() === $service) {
+                return $vs;
+            }
+        }
+        return null;
+    }
 }

--- a/src/Repository/AssistanceConfirmationRepository.php
+++ b/src/Repository/AssistanceConfirmationRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\AssistanceConfirmation;
+use App\Entity\Service;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -14,6 +15,14 @@ class AssistanceConfirmationRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, AssistanceConfirmation::class);
+    }
+
+    public function countAttendingByService(Service $service): int
+    {
+        return $this->count([
+            'service' => $service,
+            'status' => 'attending',
+        ]);
     }
 
     //    /**

--- a/src/Repository/FichajeRepository.php
+++ b/src/Repository/FichajeRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Fichaje;
+use App\Entity\VolunteerService;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Fichaje>
+ *
+ * @method Fichaje|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Fichaje|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Fichaje[]    findAll()
+ * @method Fichaje[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class FichajeRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Fichaje::class);
+    }
+
+    public function findOpenFichaje(VolunteerService $volunteerService): ?Fichaje
+    {
+        return $this->createQueryBuilder('f')
+            ->andWhere('f.volunteerService = :volunteerService')
+            ->andWhere('f.endTime IS NULL')
+            ->setParameter('volunteerService', $volunteerService)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+}

--- a/templates/service/edit_service.html.twig
+++ b/templates/service/edit_service.html.twig
@@ -248,48 +248,57 @@
                                 {% set fichaje = fichajes[confirmation.volunteer.id] ?? null %}
                                 <div class="flex items-center justify-between">
                                     <span class="font-bold">{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}</span>
-                                    <small class="text-gray-500">({{ confirmation.updatedAt|date('d/m/Y H:i') }})</small>
-                                </div>
-                                <div class="mt-2">
-                                    {% if fichaje %}
-                                        {% if fichaje.endTime %}
-                                            <span class="text-green-600 flex items-center">
-                                                <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                                                Fichaje completado
-                                            </span>
-                                            <p class="text-sm text-gray-600 mt-1">
-                                                <strong>Entrada:</strong> {{ fichaje.startTime|date('d/m/Y H:i:s') }} -
-                                                <strong>Salida:</strong> {{ fichaje.endTime|date('d/m/Y H:i:s') }}
-                                            </p>
-                                        {% else %}
-                                            <span class="text-red-600 flex items-center">
-                                                <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
-                                                Fichaje incompleto
-                                            </span>
-                                            <p class="text-sm text-gray-600 mt-1">
-                                                <strong>Entrada:</strong> {{ fichaje.startTime|date('d/m/Y H:i:s') }} -
-                                                <strong>Salida:</strong> No fichado.
-                                            </p>
+                                    <div class="flex items-center space-x-2">
+                                        {% set vs = confirmation.volunteer.getVolunteerServiceForService(service) %}
+                                        {% if vs %}
+                                            {% set openFichaje = vs.getOpenFichaje() %}
+                                            {% if openFichaje %}
+                                                <form action="{{ path('app_fichaje_clockout', {'id': vs.id}) }}" method="post" class="d-inline">
+                                                    <button type="submit" class="btn btn-warning btn-sm" title="Registrar Salida" onclick="return handleFichaje(this);">
+                                                        <i class="fas fa-clock"></i> Salida
+                                                    </button>
+                                                </form>
+                                            {% else %}
+                                                <form action="{{ path('app_fichaje_clockin', {'id': vs.id}) }}" method="post" class="d-inline">
+                                                    <button type="submit" class="btn btn-success btn-sm" title="Registrar Entrada" onclick="return handleFichaje(this);">
+                                                        <i class="fas fa-clock"></i> Entrada
+                                                    </button>
+                                                </form>
+                                            {% endif %}
                                         {% endif %}
-                                    {% else %}
-                                        <span class="text-yellow-600 flex items-center">
-                                            <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
-                                            Pendiente de fichar
-                                        </span>
-                                        <p class="text-sm text-gray-600 mt-1">
-                                            <strong>Entrada:</strong> No fichado. -
-                                            <strong>Salida:</strong> No fichado.
-                                        </p>
-                                    {% endif %}
+                                        <form method="post" action="{{ path('app_assistance_confirmation_remove', {'id': confirmation.id}) }}" onsubmit="return confirm('¿Estás seguro de que quieres eliminar la confirmación de asistencia de este voluntario? Esta acción no se puede deshacer.');">
+                                            <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ confirmation.id) }}">
+                                            <button type="submit" class="text-red-500 hover:text-red-700">
+                                                <i data-lucide="trash-2" class="h-5 w-5"></i>
+                                            </button>
+                                        </form>
+                                    </div>
                                 </div>
-                                <div class="flex justify-end mt-2">
-                                    <form method="post" action="{{ path('app_assistance_confirmation_remove', {'id': confirmation.id}) }}" onsubmit="return confirm('¿Estás seguro de que quieres eliminar la confirmación de asistencia de este voluntario? Esta acción no se puede deshacer.');">
-                                        <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ confirmation.id) }}">
-                                        <button type="submit" class="text-red-500 hover:text-red-700">
-                                            <i data-lucide="trash-2" class="h-5 w-5"></i>
-                                        </button>
-                                    </form>
-                                </div>
+
+                                {% if vs and vs.fichajes|length > 0 %}
+                                    <div class="mt-2 text-sm">
+                                        <strong>Historial:</strong>
+                                        <ul class="list-disc pl-5 mt-1">
+                                            {% for fichaje in vs.fichajes|sort((a, b) => a.startTime <=> b.startTime) %}
+                                                <li>
+                                                    {{ fichaje.startTime|date('d/m H:i') }} -
+                                                    {% if fichaje.endTime %}
+                                                        {{ fichaje.endTime|date('H:i') }}
+                                                    {% else %}
+                                                        <span class="badge bg-info text-dark">Abierto</span>
+                                                    {% endif %}
+                                                    {% if fichaje.notes %}
+                                                        <em class="text-gray-500 ml-2">"{{ fichaje.notes }}"</em>
+                                                    {% endif %}
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
+                                    </div>
+                                {% else %}
+                                    <div class="mt-2 text-sm text-gray-500 italic">
+                                        Aún no hay registros de fichaje.
+                                    </div>
+                                {% endif %}
                             </li>
                         {% else %}
                             <li class="list-group-item text-gray-500 italic">Nadie asiste todavía.</li>
@@ -425,5 +434,29 @@
                 });
             }
         });
+
+        function handleFichaje(button) {
+            const notes = prompt("Añadir una nota (opcional):");
+            if (notes !== null) { // prompt returns null if user clicks Cancel
+                const form = button.closest('form');
+
+                // Remove existing notes input if it exists
+                const existingInput = form.querySelector('input[name="notes"]');
+                if (existingInput) {
+                    existingInput.remove();
+                }
+
+                if (notes) { // Only add input if notes were provided
+                    const hiddenInput = document.createElement('input');
+                    hiddenInput.type = 'hidden';
+                    hiddenInput.name = 'notes';
+                    hiddenInput.value = notes;
+                    form.appendChild(hiddenInput);
+                }
+
+                return true; // Allow form to submit
+            }
+            return false; // Prevent form submission if user cancels
+        }
     </script>
 {% endblock %}


### PR DESCRIPTION
…ance and clock-in/out system.

Key features and changes include:

1.  **New Individual Clock-in/Out System:**
    -   A new `Fichaje` entity and database table have been created to store multiple, individual clock-in and clock-out records for each volunteer per service.
    -   Volunteers can now be clocked in and out multiple times for a single service, and optional notes can be added to each entry.
    -   The UI in the service management page has been updated with buttons for individual clock-in/out and a history display.

2.  **Dynamic Attendance & Reserve List:**
    -   The system now correctly handles dynamic attendance confirmation. Volunteers are added to a 'Reserve' list if a service with a capacity limit is full.
    -   When a spot opens up, the first volunteer from the reserve list is automatically promoted to 'Attending'.
    -   The `VolunteerService` records required for the clock-in system are now created and deleted in sync with the volunteer's attendance status.

3.  **Core Calculation Logic:**
    -   A new `calculateTotalDuration()` method has been implemented. This method accurately calculates a volunteer's total service time by summing all their clock-in/out intervals.
    -   Crucially, if a clock-in record is left open (no clock-out), the system now uses the service's official end time for the calculation, as per the requirement.

4.  **Refactoring and Cleanup:**
    -   The old "Fichar a todos" (mass clock-in) feature has been refactored to use the new `Fichaje` system, ensuring it correctly overwrites all previous clock-in records for the service.
    -   The obsolete `startTime`, `endTime`, `duration`, and `notes` columns have been removed from the `volunteer_service` table, and the `VolunteerService` entity has been cleaned up.
    -   Reporting has been updated to use the new, more accurate calculation method.