### PR TITLE
Fix UndefinedMethodError for isHasAttended

### DIFF
--- a/src/Entity/AssistanceConfirmation.php
+++ b/src/Entity/AssistanceConfirmation.php
@@ -90,4 +90,9 @@ class AssistanceConfirmation
     {
         return $this->updatedAt;
     }
+
+    public function isHasAttended(): bool
+    {
+        return $this->status === self::STATUS_ATTENDING;
+    }
 }


### PR DESCRIPTION
The DashboardController was calling a non-existent method `isHasAttended()` on the AssistanceConfirmation entity, causing a fatal error.

This commit adds the `isHasAttended()` method to the `AssistanceConfirmation` entity. The method encapsulates the logic for checking the attendance status, returning true if the status is 'attending'.

This is a cleaner solution than checking the status directly in the controller, as it keeps the business logic within the entity itself.