### PR TITLE
Feat: Individual time tracking and fix related bugs

### DIFF
--- a/src/Repository/VolunteerServiceRepository.php
+++ b/src/Repository/VolunteerServiceRepository.php
@@ -16,6 +16,21 @@ class VolunteerServiceRepository extends ServiceEntityRepository
         parent::__construct($registry, VolunteerService::class);
     }
 
+    /**
+     * @return VolunteerService[]
+     */
+    public function findForVolunteerOrderedByServiceDate(\App\Entity\Volunteer $volunteer): array
+    {
+        return $this->createQueryBuilder('vs')
+            ->innerJoin('vs.service', 's')
+            ->andWhere('vs.volunteer = :volunteer')
+            ->setParameter('volunteer', $volunteer)
+            ->orderBy('s.startDate', 'DESC')
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
     //    /**
     //     * @return VolunteerService[] Returns an array of VolunteerService objects
     //     */


### PR DESCRIPTION
This commit introduces a new feature for detailed time tracking and fixes two underlying bugs.

**New Feature: Individual Time Tracking**
- Replaces the simple clock-in/out buttons with a more flexible system for managing volunteer hours on the service details page.
- **Display Total Hours:** Each volunteer in the "attending" list now shows their total calculated hours for the service.
- **Manual Fichaje:** A new "add" button for each volunteer opens a modal to manually enter a new time record (`Fichaje`) with start date/time, end date/time, and notes.
- **Edit/Delete Fichajes:** The history of time entries for each volunteer now includes buttons (on hover) to edit or delete each individual record.
- **Backend Support:** New controller actions in `FichajeController` and a Stimulus controller (`service_form_controller.js`) have been added to handle the full lifecycle of these individual `Fichaje` records.

**Bug Fixes:**
1.  **UndefinedMethodError:** Resolves an "UndefinedMethodError" by adding the missing `volunteerServices` OneToMany relationship to the `Service` entity.
2.  **UnrecognizedField on "My Services" Page:** Fixes an error on the `/mis-servicios` page caused by an incorrect query. A new repository method was created to properly fetch and sort `VolunteerService` entities by the service's start date, and a call to a non-existent `getDuration()` method was corrected.