### PR TITLE
Fix Twig template errors in my_services.html.twig

### DIFF
--- a/templates/service/my_services.html.twig
+++ b/templates/service/my_services.html.twig
@@ -63,9 +63,10 @@
                                 <td class="p-2 text-sm">{{ volunteerService.service.title }}</td>
                                 <td class="p-2 text-sm">{{ volunteerService.service.startDate ? volunteerService.service.startDate|date('d/m/Y H:i') : 'N/A' }}</td>
                                 <td class="p-2 text-sm">
-                                    {% if volunteerService.duration %}
-                                        {% set hours = (volunteerService.duration / 60)|round(0, 'floor') %}
-                                        {% set minutes = volunteerService.duration % 60 %}
+                                    {% set duration = volunteerService.calculateTotalDuration() %}
+                                    {% if duration %}
+                                        {% set hours = (duration / 60)|round(0, 'floor') %}
+                                        {% set minutes = duration % 60 %}
                                         {{ hours ~ 'h ' ~ minutes ~ 'm' }}
                                     {% else %}
                                         N/A


### PR DESCRIPTION
This commit fixes two separate but related Twig runtime errors in the `my_services.html.twig` template:

1.  The template was attempting to access a non-existent `startTime` property on the `VolunteerService` entity. This was corrected to use the `startDate` property from the related `Service` entity (`lastService.service.startDate`).

2.  The template was also attempting to access a non-existent `duration` property on the `VolunteerService` entity. This was corrected to call the existing `calculateTotalDuration()` method, which correctly calculates the total duration of a volunteer's service.