### PR TITLE
Fix individual clock-in functionality and update icon

### DIFF
--- a/templates/service/edit_service.html.twig
+++ b/templates/service/edit_service.html.twig
@@ -266,7 +266,7 @@
                                                     data-action="click->service-form#openIndividualFichajeModal"
                                                     data-volunteer-service-id="{{ vs.id }}"
                                                     data-volunteer-name="{{ confirmation.volunteer.name }} {{ confirmation.volunteer.lastname }}">
-                                                <i data-lucide="plus-circle" class="h-5 w-5"></i>
+                                                <i data-lucide="clock" class="h-5 w-5"></i>
                                             </button>
                                         {% endif %}
                                         <form method="post" action="{{ path('app_assistance_confirmation_remove', {'id': confirmation.id}) }}" onsubmit="return confirm('¿Estás seguro de que quieres eliminar la confirmación de asistencia de este voluntario? Esta acción no se puede deshacer.');">
@@ -438,10 +438,10 @@
             </div>
         </div>
     </div>
-</div>
 
-{{ include('service/_fichar_modal.html.twig') }}
-{{ include('service/_individual_fichaje_modal.html.twig') }}
+    {{ include('service/_fichar_modal.html.twig') }}
+    {{ include('service/_individual_fichaje_modal.html.twig') }}
+</div>
 
 {% endblock %}
 


### PR DESCRIPTION
This commit resolves an issue where the individual clock-in button was not working and updates the icon as requested.

The primary issue was that the clock-in modal, included via a separate template, was outside the scope of the main Stimulus controller (`service-form`). This prevented the controller from finding the necessary targets and actions within the modal. The fix involved moving the `include` statement for the modal inside the `div` element that defines the controller's scope.

Additionally, the 'plus-circle' icon for the clock-in button has been replaced with a more appropriate 'clock' icon to better reflect its function.