### PR TITLE
feat: Sort fichajes by start time

### DIFF
--- a/src/Entity/VolunteerService.php
+++ b/src/Entity/VolunteerService.php
@@ -28,6 +28,7 @@ class VolunteerService
     private ?Service $service = null;
 
     #[ORM\OneToMany(mappedBy: 'volunteerService', targetEntity: Fichaje::class, cascade: ['persist', 'remove'])]
+    #[ORM\OrderBy(['startTime' => 'ASC'])]
     private Collection $fichajes;
 
     public function __construct()


### PR DESCRIPTION
Adds an OrderBy annotation to the fichajes collection in the VolunteerService entity to ensure the clock-in/out records are always displayed in chronological order based on their start time.