### PR TITLE
fix: Correct clock-in history sort order

### DIFF
--- a/templates/service/edit_service.html.twig
+++ b/templates/service/edit_service.html.twig
@@ -293,7 +293,7 @@
                                     <div class="mt-3 text-sm">
                                         <h5 class="font-semibold text-gray-700">Historial de Fichajes:</h5>
                                         <ul class="list-disc pl-5 mt-1 space-y-1 text-gray-600">
-                                            {% for fichaje_item in vs.fichajes|sort((a, b) => b.startTime <=> a.startTime) %}
+                                            {% for fichaje_item in vs.fichajes|sort((a, b) => a.startTime <=> b.startTime) %}
                                                 <li class="flex justify-between items-center group">
                                                     <span>
                                                         {{ fichaje_item.startTime|date('d/m H:i') }} -


### PR DESCRIPTION
This commit fixes the sort order of the clock-in history to be chronological (ascending).

- Modifies the Twig sort filter in `edit_service.html.twig` to use `a.startTime <=> b.startTime`.