### PR TITLE
feat: Add 'Save and Add Another' and improve 'My Services' view

### DIFF
--- a/assets/controllers/service_details_controller.js
+++ b/assets/controllers/service_details_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ["details", "icon"];
+
+    toggle() {
+        this.detailsTarget.classList.toggle('hidden');
+        this.iconTarget.classList.toggle('rotate-180');
+    }
+}

--- a/assets/controllers/service_form_controller.js
+++ b/assets/controllers/service_form_controller.js
@@ -369,4 +369,63 @@ renderPagination(pagination, items) {
         }
         document.getElementById('individual-notes').value = notes;
     }
+
+    async saveAndAddAnother(event) {
+        event.preventDefault();
+        const form = this.individualFichajeModalTarget.querySelector('form');
+        const formData = new FormData(form);
+        const url = form.action;
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                },
+                body: new URLSearchParams(formData)
+            });
+
+            const result = await response.json();
+
+            if (!response.ok) {
+                throw new Error(result.message || 'Ocurrió un error.');
+            }
+
+            this.showToast(result.message);
+
+            // Clear the form for the next entry
+            document.getElementById('individual-start-date').value = '';
+            document.getElementById('individual-start-time').value = '';
+            document.getElementById('individual-end-date').value = '';
+            document.getElementById('individual-end-time').value = '';
+            document.getElementById('individual-notes').value = '';
+
+            // Update the last clock-out time display
+            if (this.hasLastClockOutTimeTarget && result.lastClockOut) {
+                const date = new Date(result.lastClockOut);
+                this.lastClockOutTimeTarget.textContent = date.toLocaleString('es-ES', {
+                    year: 'numeric', month: '2-digit', day: '2-digit',
+                    hour: '2-digit', minute: '2-digit'
+                });
+            }
+
+            // Optionally, focus the first input for quick entry
+            document.getElementById('individual-start-date').focus();
+
+        } catch (error) {
+            this.showToast(error.message, 'error');
+        }
+    }
+
+    showToast(message, type = 'success') {
+        const toast = document.createElement('div');
+        toast.className = `fixed bottom-5 right-5 p-4 rounded-lg shadow-lg text-white ${type === 'success' ? 'bg-green-500' : 'bg-red-500'}`;
+        toast.textContent = message;
+
+        document.body.appendChild(toast);
+
+        setTimeout(() => {
+            toast.remove();
+        }, 3000);
+    }
 }

--- a/templates/service/_individual_fichaje_modal.html.twig
+++ b/templates/service/_individual_fichaje_modal.html.twig
@@ -50,12 +50,16 @@
 
             <div class="flex justify-end space-x-4 border-t pt-4">
                 <button type="button" data-action="click->service-form#closeIndividualFichajeModal"
-                        class="px-6 py-3 bg-gray-200 text-gray-800 font-semibold rounded-lg shadow-md hover:bg-gray-300">
+                        class="px-6 py-2 bg-gray-200 text-gray-800 font-semibold rounded-lg shadow-md hover:bg-gray-300">
                     Cancelar
                 </button>
+                <button type="button" data-action="click->service-form#saveAndAddAnother"
+                        class="px-6 py-2 bg-green-600 text-white font-semibold rounded-lg shadow-md hover:bg-green-700">
+                    Guardar y Añadir Otro
+                </button>
                 <button type="submit"
-                        class="px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700">
-                    Guardar Fichaje
+                        class="px-6 py-2 bg-blue-600 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700">
+                    Guardar y Cerrar
                 </button>
             </div>
         </form>

--- a/templates/service/my_services.html.twig
+++ b/templates/service/my_services.html.twig
@@ -59,17 +59,42 @@
                     </thead>
                     <tbody>
                         {% for volunteerService in volunteerServices %}
-                            <tr class="border-b border-gray-200">
+                            <tr class="border-b border-gray-200" data-controller="service-details">
                                 <td class="p-2 text-sm">{{ volunteerService.service.title }}</td>
-                                <td class="p-2 text-sm">{{ volunteerService.service.startDate ? volunteerService.service.startDate|date('d/m/Y H:i') : 'N/A' }}</td>
+                                <td class="p-2 text-sm">{{ volunteerService.service.startDate ? volunteerService.service.startDate|date('d/m/Y') : 'N/A' }}</td>
                                 <td class="p-2 text-sm">
-                                    {% set duration = volunteerService.calculateTotalDuration() %}
-                                    {% if duration %}
-                                        {% set hours = (duration / 60)|round(0, 'floor') %}
-                                        {% set minutes = duration % 60 %}
-                                        {{ hours ~ 'h ' ~ minutes ~ 'm' }}
-                                    {% else %}
-                                        N/A
+                                    <div class="flex items-center justify-between">
+                                        <span>
+                                            {% set duration = volunteerService.calculateTotalDuration() %}
+                                            {% if duration %}
+                                                {% set hours = (duration / 60)|round(0, 'floor') %}
+                                                {% set minutes = duration % 60 %}
+                                                {{ hours ~ 'h ' ~ minutes ~ 'm' }}
+                                            {% else %}
+                                                N/A
+                                            {% endif %}
+                                        </span>
+                                        {% if volunteerService.fichajes|length > 0 %}
+                                            <button data-action="click->service-details#toggle" class="p-1 text-gray-500 hover:text-gray-700">
+                                                <i data-lucide="chevron-down" class="h-5 w-5 transition-transform" data-service-details-target="icon"></i>
+                                            </button>
+                                        {% endif %}
+                                    </div>
+                                    {% if volunteerService.fichajes|length > 0 %}
+                                        <div class="hidden mt-2 p-2 bg-gray-50 rounded-md" data-service-details-target="details">
+                                            <h4 class="font-semibold text-xs mb-1">Desglose de Fichajes:</h4>
+                                            <ul class="list-disc pl-5 text-xs space-y-1">
+                                                {% for fichaje in volunteerService.fichajes|sort((a, b) => a.startTime <=> b.startTime) %}
+                                                    <li>
+                                                        {{ fichaje.startTime|date('H:i') }} -
+                                                        {{ fichaje.endTime ? fichaje.endTime|date('H:i') : 'Abierto' }}
+                                                        {% if fichaje.notes %}
+                                                            <em class="text-gray-500">({{ fichaje.notes }})</em>
+                                                        {% endif %}
+                                                    </li>
+                                                {% endfor %}
+                                            </ul>
+                                        </div>
                                     {% endif %}
                                 </td>
                             </tr>


### PR DESCRIPTION
This commit introduces two new features based on user feedback:

1.  **'Save and Add Another' in Clock-In Modal:**
    - Adds a 'Guardar y Añadir Otro' button to the individual clock-in modal.
    - Implements an AJAX-based submission that saves the current entry and clears the form without closing the modal, allowing for rapid entry of multiple records.
    - The backend controller now handles both standard and AJAX requests, returning JSON with the latest clock-out time for dynamic updates.

2.  **'My Services' View Enhancements:**
    - Updates the `my_services.html.twig` template to show only the date instead of the full timestamp.
    - Adds a collapsible section for each service to show a detailed breakdown of all clock-in/out records.
    - Creates a new Stimulus controller (`service-details-controller.js`) to manage the toggle functionality for the details section.