### PR TITLE
feat: Update color scheme to blue and orange

### DIFF
--- a/templates/layout/sidebar.html.twig
+++ b/templates/layout/sidebar.html.twig
@@ -40,7 +40,7 @@
         <ul class="space-y-1">
             {% macro nav_link(path, icon, label, is_active = false) %}
                 <li>
-                    <a href="{{ path(path) }}"
+                    <a href="{{ path == '#' ? '#' : path(path) }}"
                        class="flex items-center gap-3 px-3 py-2 rounded-lg transition-colors group
                               {{ is_active
                                  ? 'bg-primary-light text-white font-semibold shadow-inner'
@@ -65,7 +65,7 @@
 
             {% macro submenu_item(path, label, is_active = false) %}
                  <li>
-                    <a href="{{ path is not null ? path(path) : '#' }}"
+                    <a href="{{ path is null or path == '#' ? '#' : path(path) }}"
                        class="block px-3 py-2 text-sm rounded-lg transition-colors
                               {{ is_active
                                  ? 'bg-primary-light text-white font-medium'


### PR DESCRIPTION
- Defines a new color palette in `tailwind.config.js` with `primary` (blue) and `accent` (orange) colors.
- Applies the new color scheme across the application, including the sidebar, login page, and main layout.
- Refactors Twig templates to use semantic color names for better maintainability.
- Improves the sidebar navigation by using Twig macros to reduce code duplication.
- Fixes a bug where placeholder links in the sidebar caused a crash.