### PR TITLE
feat: Personalizar la página de inicio de sesión

### DIFF
--- a/jules-scratch/verification/verify_login_page.py
+++ b/jules-scratch/verification/verify_login_page.py
@@ -1,0 +1,32 @@
+from playwright.sync_api import sync_playwright, Page, expect
+
+def test_login_page_modifications(page: Page):
+    """
+    This test verifies the new look of the login page.
+    """
+    # 1. Arrange: Go to the login page.
+    # The Symfony server runs on port 8000 by default.
+    page.goto("http://127.0.0.1:8000/login")
+
+    # 2. Assert: Check for the new elements.
+    # Check that the title is correct.
+    expect(page.locator("p.text-primary-light")).to_have_text("Protección civil de Vigo")
+
+    # Check that the "Forgot password" link is there.
+    forgot_password_link = page.get_by_role("link", name="¿Has olvidado tu contraseña?")
+    expect(forgot_password_link).to_be_visible()
+
+    # Check that the logo placeholder is there (it will be a broken image for now)
+    logo = page.get_by_alt_text("Logo Protección Civil Vigo")
+    expect(logo).to_be_visible()
+
+    # 3. Screenshot: Capture the final result for visual verification.
+    page.screenshot(path="jules-scratch/verification/login_page.png")
+
+# Boilerplate to run the test
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        test_login_page_modifications(page)
+        browser.close()

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -6,11 +6,9 @@
 <div class="min-h-screen bg-gradient-to-br from-primary-dark via-primary to-primary-light flex items-center justify-center p-4">
     <div class="max-w-md w-full">
         <div class="text-center mb-8">
-            <div class="inline-flex items-center justify-center w-16 h-16 bg-white/20 backdrop-blur-sm rounded-full mb-4 border border-white/30">
-                <i data-lucide="users" class="w-8 h-8 text-white"></i>
-            </div>
+            <img src="{{ asset('images/logo.png') }}" alt="Logo Protección Civil Vigo" class="mx-auto h-24 w-auto mb-4">
             <h1 class="text-3xl font-bold text-white mb-2">Sistema de Gestión</h1>
-            <p class="text-primary-light">Gestión de Voluntarios</p>
+            <p class="text-primary-light">Protección civil de Vigo</p>
         </div>
 
         <div class="bg-white rounded-2xl shadow-2xl p-8">
@@ -56,10 +54,10 @@
                 </div>
             </form>
 
-            <div class="mt-6 p-4 bg-primary/10 rounded-lg border border-primary/20">
-                <p class="text-sm text-primary-dark text-center">
-                    <strong>Demo:</strong> admin@voluntarios.org / admin123
-                </p>
+            <div class="mt-6 text-center">
+                <a href="#" class="text-sm text-primary hover:underline">
+                    ¿Has olvidado tu contraseña?
+                </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Este commit introduce las siguientes modificaciones en la página de inicio de sesión:

- Se ha añadido un espacio para el logo de la organización encima del título.
- Se ha actualizado el subtítulo de "Gestión de Voluntarios" a "Protección civil de Vigo".
- Se ha eliminado la sección de demostración que mostraba las credenciales de prueba.
- Se ha añadido un enlace para la recuperación de contraseña.

Se ha dejado un marcador de posición para el logo y se ha informado al usuario de que debe subir el archivo `logo.png` a la carpeta `public/images/` para que se muestre correctamente.