### PR TITLE
feat: Update login page content and add password recovery link

### DIFF
--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -56,10 +56,8 @@
                 </div>
             </form>
 
-            <div class="mt-6 p-4 bg-blue-50 rounded-lg">
-                <p class="text-sm text-blue-800 text-center">
-                    <strong>Demo:</strong> admin@voluntarios.org / admin123
-                </p>
+            <div class="mt-6 text-center">
+                <a href="#" class="text-sm text-blue-600 hover:underline">Recuperar contraseña</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This commit updates the login page based on user feedback.

Changes include:
- Updating the main heading to "Protección Civil de Vigo".
- Updating the subheading to "Sistema de Gestión".
- Removing the section displaying demo user credentials.
- Adding a "Recuperar contraseña" (Recover password) link.