### PR TITLE
docs: Add comprehensive documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,128 @@
-# Sistema de Gestión de Voluntarios - Symfony + XAMPP
+# Protección Civil de Vigo - Volunteer Management System
 
-## Instalación y Configuración
+## 1. Overview
 
-### PASO 1: Preparar XAMPP
-1. Descargar e instalar XAMPP desde https://www.apachefriends.org/
-2. Iniciar Apache y MySQL desde el panel de control
-3. Crear base de datos `gestion_voluntarios` en phpMyAdmin
+This project is a comprehensive web application designed to manage the volunteers and activities of the Protección Civil de Vigo. It provides a centralized platform for administrators to handle volunteer data, create and manage services, track attendance, and oversee vehicle and resource allocation. Volunteers can use the system to view and sign up for services, and track their participation hours.
 
-### PASO 2: Crear Proyecto Symfony
+### Key Features
+
+*   **Volunteer Management:** Create, edit, and view volunteer profiles with detailed personal, contact, and qualification information.
+*   **Service Management:** Schedule and manage services, including details on location, timing, required resources, and tasks.
+*   **Attendance Tracking:** Volunteers can confirm their attendance for services. Administrators can manage attendance lists, including a reserve list system for full events.
+*   **Clock-in/Out System (Fichaje):** Detailed time tracking for each volunteer per service, with options for both individual and mass clock-ins.
+*   **Dashboard:** Role-based dashboards providing at-a-glance statistics for administrators and service listings for volunteers.
+*   **Resource Management:** Basic management of vehicles and fuel types.
+*   **User Roles:** Differentiates between regular volunteers, coordinators, and administrators with specific permissions.
+
+---
+
+## 2. Tech Stack
+
+*   **Backend:** PHP 8.2+ / Symfony 6.4+
+*   **Database:** MySQL / MariaDB (using Doctrine ORM)
+*   **Frontend:** Twig Templating, JavaScript, Tailwind CSS
+*   **Package Managers:** Composer (PHP), npm (JavaScript)
+*   **Development Server:** Symfony CLI
+
+---
+
+## 3. Prerequisites
+
+Before you begin, ensure you have the following installed on your local machine:
+*   PHP 8.2 or higher
+*   Composer
+*   Symfony CLI
+*   Node.js and npm
+*   A local database server (e.g., MariaDB via XAMPP, Docker)
+
+---
+
+## 4. Setup and Installation
+
+Follow these steps to get the project running on your local machine.
+
+### Step 1: Clone the Repository
 ```bash
-cd C:\xampp\htdocs
-composer create-project symfony/skeleton gestion-voluntarios
-cd gestion-voluntarios
-composer require webapp symfony/orm-pack symfony/form symfony/validator symfony/security-bundle
+git clone <repository-url>
+cd <project-directory>
 ```
 
-### PASO 3: Configurar Base de Datos
-Editar `.env`:
-```
-DATABASE_URL="mysql://root:@127.0.0.1:3306/gestion_voluntarios?serverVersion=8.0.32&charset=utf8mb4"
-```
-
-### PASO 4: Ejecutar Migraciones
+### Step 2: Install PHP Dependencies
+Install all the required backend libraries using Composer.
 ```bash
-php bin/console doctrine:migrations:migrate
-php bin/console app:create-user
+composer install
 ```
 
-### PASO 5: Iniciar Servidor
+### Step 3: Configure Environment
+1.  Create a local environment file by copying the example:
+    ```bash
+    cp .env .env.local
+    ```
+2.  Open `.env.local` and configure your `DATABASE_URL`.
+    *   **Example for XAMPP/MariaDB:**
+        ```
+        DATABASE_URL="mysql://root:@127.0.0.1:3306/proteccion_civil_vigo?serverVersion=10.4.32-MariaDB&charset=utf8mb4"
+        ```
+    *   **Note:** Replace `root` with your database username and `` with your password if you have one. Adjust the `serverVersion` to match your database server.
+
+### Step 4: Set Up the Database
+1.  Create the database specified in your `.env.local` file. You can use a tool like phpMyAdmin or run the following command:
+    ```bash
+    php bin/console doctrine:database:create
+    ```
+2.  Run the database migrations to create all the necessary tables:
+    ```bash
+    php bin/console doctrine:migrations:migrate
+    ```
+
+### Step 5: Install Frontend Dependencies & Build Assets
+1.  Install the Node.js packages:
+    ```bash
+    npm install
+    ```
+2.  Compile and build the frontend assets (CSS, JS):
+    ```bash
+    npm run build
+    ```
+
+---
+
+## 5. Running the Application
+
+### Backend Server
+Start the Symfony local web server.
 ```bash
-symfony server:start
+symfony server:start -d
+```
+The `-d` flag runs the server in the background. You can view the application at the URL provided in the output (usually `https://127.0.0.1:8000`).
+
+### Frontend Development
+If you are making changes to frontend files (CSS or JavaScript), you can run the development server in a separate terminal to enable hot-reloading.
+```bash
+npm run dev
 ```
 
-## Credenciales de Acceso
-- Email: admin@voluntarios.org
-- Password: admin123
+### Access Credentials
+An administrator account is created by default.
+*   **Email:** `admin@voluntarios.org`
+*   **Password:** `admin123`
+
+---
+
+## 6. Project Structure
+
+Here is a brief overview of the key directories in the project:
+
+*   `src/`
+    *   `Controller/`: Contains all the application's controllers that handle requests.
+    *   `Entity/`: Contains all the Doctrine database entities.
+    *   `Form/`: Contains all the Symfony form type classes.
+    *   `Repository/`: Contains all the Doctrine repositories for database queries.
+    *   `Service/`: Contains custom application services (e.g., `WhatsAppMessageGenerator`).
+    *   `Security/`: Contains security-related classes, like Voters.
+    *   `Twig/`: Contains custom Twig extensions.
+*   `templates/`: Contains all the Twig template files for rendering HTML.
+*   `assets/`: Contains frontend source files (JavaScript, CSS).
+*   `migrations/`: Contains the Doctrine database migration files.
+*   `public/`: The web root directory. Compiled assets and uploaded files are stored here.
+*   `config/`: Contains all application configuration files.

--- a/src/Controller/Admin/FuelTypeController.php
+++ b/src/Controller/Admin/FuelTypeController.php
@@ -11,9 +11,18 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
+/**
+ * Controller for managing fuel types in the admin panel.
+ */
 #[Route('/admin/fuel-types')]
 class FuelTypeController extends AbstractController
 {
+    /**
+     * Displays a list of all fuel types.
+     *
+     * @param FuelTypeRepository $fuelTypeRepository The repository for fuel types.
+     * @return Response The response object.
+     */
     #[Route('/', name: 'app_admin_fuel_type_index', methods: ['GET'])]
     public function index(FuelTypeRepository $fuelTypeRepository): Response
     {
@@ -22,6 +31,13 @@ class FuelTypeController extends AbstractController
         ]);
     }
 
+    /**
+     * Creates a new fuel type.
+     *
+     * @param Request $request The request object.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @return Response The response object.
+     */
     #[Route('/new', name: 'app_admin_fuel_type_new', methods: ['GET', 'POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): Response
     {
@@ -44,6 +60,14 @@ class FuelTypeController extends AbstractController
         ]);
     }
 
+    /**
+     * Edits an existing fuel type.
+     *
+     * @param Request $request The request object.
+     * @param FuelType $fuelType The fuel type to edit.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @return Response The response object.
+     */
     #[Route('/{id}/edit', name: 'app_admin_fuel_type_edit', methods: ['GET', 'POST'])]
     public function edit(Request $request, FuelType $fuelType, EntityManagerInterface $entityManager): Response
     {
@@ -64,6 +88,14 @@ class FuelTypeController extends AbstractController
         ]);
     }
 
+    /**
+     * Deletes a fuel type.
+     *
+     * @param Request $request The request object.
+     * @param FuelType $fuelType The fuel type to delete.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @return Response The response object.
+     */
     #[Route('/{id}', name: 'app_admin_fuel_type_delete', methods: ['POST'])]
     public function delete(Request $request, FuelType $fuelType, EntityManagerInterface $entityManager): Response
     {

--- a/src/Controller/ComingSoonController.php
+++ b/src/Controller/ComingSoonController.php
@@ -6,8 +6,16 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
+/**
+ * Controller for displaying "coming soon" pages for unimplemented features.
+ */
 class ComingSoonController extends AbstractController
 {
+    /**
+     * Renders the "coming soon" page for the services list.
+     *
+     * @return Response The response object.
+     */
     #[Route('/servicios/listado', name: 'app_services_list')]
     public function servicesList(): Response
     {
@@ -17,6 +25,11 @@ class ComingSoonController extends AbstractController
         ]);
     }
 
+    /**
+     * Renders the "coming soon" page for service reports.
+     *
+     * @return Response The response object.
+     */
     #[Route('/servicios/informes', name: 'app_services_reports')]
     public function servicesReports(): Response
     {
@@ -26,6 +39,11 @@ class ComingSoonController extends AbstractController
         ]);
     }
 
+    /**
+     * Renders the "coming soon" page for service schedules.
+     *
+     * @return Response The response object.
+     */
     #[Route('/servicios/cuadrantes', name: 'app_services_schedules')]
     public function servicesSchedules(): Response
     {
@@ -35,6 +53,11 @@ class ComingSoonController extends AbstractController
         ]);
     }
 
+    /**
+     * Renders the "coming soon" page for communications.
+     *
+     * @return Response The response object.
+     */
     #[Route('/comunicados', name: 'app_communications')]
     public function communications(): Response
     {
@@ -44,6 +67,11 @@ class ComingSoonController extends AbstractController
         ]);
     }
 
+    /**
+     * Renders the "coming soon" page for vehicle management.
+     *
+     * @return Response The response object.
+     */
     #[Route('/vehiculos', name: 'app_vehicles')]
     public function vehicles(): Response
     {
@@ -53,6 +81,11 @@ class ComingSoonController extends AbstractController
         ]);
     }
 
+    /**
+     * Renders the "coming soon" page for document management.
+     *
+     * @return Response The response object.
+     */
     #[Route('/gesdoc', name: 'app_gesdoc')]
     public function gesdoc(): Response
     {
@@ -62,6 +95,11 @@ class ComingSoonController extends AbstractController
         ]);
     }
 
+    /**
+     * Renders the "coming soon" page for the communications central.
+     *
+     * @return Response The response object.
+     */
     #[Route('/central', name: 'app_central')]
     public function central(): Response
     {
@@ -71,6 +109,11 @@ class ComingSoonController extends AbstractController
         ]);
     }
 
+    /**
+     * Renders the "coming soon" page for statistics and reports.
+     *
+     * @return Response The response object.
+     */
     #[Route('/estadisticas', name: 'app_statistics')]
     public function statistics(): Response
     {

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -12,8 +12,26 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\SecurityBundle\Security;
 
+/**
+ * Controller for displaying the main dashboard.
+ */
 class DashboardController extends AbstractController
 {
+    /**
+     * Renders the dashboard for the currently logged-in user.
+     *
+     * This method checks the user's role and renders the appropriate dashboard:
+     * - Admin dashboard with statistics for administrators.
+     * - Volunteer dashboard with service information for volunteers.
+     * If the user is not logged in, it redirects to the login page.
+     *
+     * @param VolunteerRepository $volunteerRepository Repository for volunteer data.
+     * @param ServiceRepository $serviceRepository Repository for service data.
+     * @param VehicleRepository $vehicleRepository Repository for vehicle data.
+     * @param AssistanceConfirmationRepository $assistanceConfirmationRepository Repository for assistance confirmation data.
+     * @param Security $security The security component.
+     * @return Response The response object, either a rendered template or a redirection.
+     */
     #[Route('/', name: 'app_dashboard')]
     public function index(
         VolunteerRepository $volunteerRepository,

--- a/src/Controller/FichajeController.php
+++ b/src/Controller/FichajeController.php
@@ -15,8 +15,23 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
+/**
+ * Controller for managing volunteer clock-in/out records (Fichajes).
+ */
 class FichajeController extends AbstractController
 {
+    /**
+     * Handles mass clock-in/out for multiple volunteers in a service.
+     * This method takes a start and end time from the request and applies it to all selected volunteers,
+     * creating a single `Fichaje` record for each. It also cleans up any previous records for the service.
+     *
+     * @param Request $request The request object containing form data.
+     * @param Service $service The service to which the clock-in/out records belong.
+     * @param EntityManagerInterface $entityManager The entity manager for database operations.
+     * @param VolunteerRepository $volunteerRepository The repository for volunteers.
+     * @param VolunteerServiceRepository $volunteerServiceRepository The repository for volunteer-service associations.
+     * @return Response A redirection to the service edit page.
+     */
     #[Route('/service/{id}/fichaje', name: 'app_fichaje', methods: ['POST'])]
     public function fichaje(Request $request, Service $service, EntityManagerInterface $entityManager, VolunteerRepository $volunteerRepository, VolunteerServiceRepository $volunteerServiceRepository): Response
     {
@@ -83,6 +98,17 @@ class FichajeController extends AbstractController
         return $this->redirectToRoute('app_service_edit', ['id' => $service->getId(), '_fragment' => 'asistencias']);
     }
 
+    /**
+     * Adds an individual clock-in/out record for a volunteer in a service.
+     * This can be called via a standard form submission or an AJAX request.
+     * It validates the input and prevents creating overlapping time entries.
+     *
+     * @param Request $request The request object.
+     * @param VolunteerService $volunteerService The association between the volunteer and the service.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @param FichajeRepository $fichajeRepository The repository for clock-in/out records.
+     * @return Response A JSON response for AJAX requests or a redirection for standard requests.
+     */
     #[Route('/volunteer_service/{id}/add_fichaje', name: 'app_fichaje_add_individual', methods: ['POST'])]
     public function addIndividualFichaje(Request $request, VolunteerService $volunteerService, EntityManagerInterface $entityManager, FichajeRepository $fichajeRepository): Response
     {
@@ -163,6 +189,16 @@ class FichajeController extends AbstractController
         }
     }
 
+    /**
+     * Creates a new, open-ended clock-in record for a volunteer at the current time.
+     * It prevents creating a new record if one is already open for the volunteer.
+     *
+     * @param Request $request The request object.
+     * @param VolunteerService $volunteerService The association between the volunteer and the service.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @param FichajeRepository $fichajeRepository The repository for clock-in/out records.
+     * @return Response A redirection to the service edit page.
+     */
     #[Route('/volunteer_service/{id}/clockin', name: 'app_fichaje_clockin', methods: ['POST'])]
     public function clockIn(Request $request, VolunteerService $volunteerService, EntityManagerInterface $entityManager, FichajeRepository $fichajeRepository): Response
     {
@@ -197,6 +233,15 @@ class FichajeController extends AbstractController
         return $this->redirectToRoute('app_service_edit', ['id' => $volunteerService->getService()->getId(), '_fragment' => 'asistencias']);
     }
 
+    /**
+     * Closes an existing open clock-in record for a volunteer at the current time.
+     *
+     * @param Request $request The request object.
+     * @param VolunteerService $volunteerService The association between the volunteer and the service.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @param FichajeRepository $fichajeRepository The repository for clock-in/out records.
+     * @return Response A redirection to the service edit page.
+     */
     #[Route('/volunteer_service/{id}/clockout', name: 'app_fichaje_clockout', methods: ['POST'])]
     public function clockOut(Request $request, VolunteerService $volunteerService, EntityManagerInterface $entityManager, FichajeRepository $fichajeRepository): Response
     {
@@ -223,6 +268,14 @@ class FichajeController extends AbstractController
         return $this->redirectToRoute('app_service_edit', ['id' => $volunteerService->getService()->getId(), '_fragment' => 'asistencias']);
     }
 
+    /**
+     * Deletes a specific clock-in/out record.
+     *
+     * @param Request $request The request object.
+     * @param Fichaje $fichaje The clock-in/out record to delete.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @return Response A redirection to the service edit page.
+     */
     #[Route('/fichaje/{id}/delete', name: 'app_fichaje_delete', methods: ['POST'])]
     public function deleteFichaje(Request $request, Fichaje $fichaje, EntityManagerInterface $entityManager): Response
     {
@@ -242,6 +295,14 @@ class FichajeController extends AbstractController
         return $this->redirectToRoute('app_service_edit', ['id' => $serviceId, '_fragment' => 'asistencias']);
     }
 
+    /**
+     * Edits an existing clock-in/out record.
+     *
+     * @param Request $request The request object containing the updated data.
+     * @param Fichaje $fichaje The clock-in/out record to edit.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @return Response A redirection to the service edit page.
+     */
     #[Route('/fichaje/{id}/edit', name: 'app_fichaje_edit', methods: ['POST'])]
     public function editFichaje(Request $request, Fichaje $fichaje, EntityManagerInterface $entityManager): Response
     {

--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -9,14 +9,29 @@ use App\Repository\VolunteerServiceRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Security\Core\User\UserInterface;
 
+/**
+ * Controller for generating and displaying reports.
+ */
 class ReportController extends AbstractController
 {
+    /**
+     * Renders the main reports page.
+     *
+     * @return Response The response object.
+     */
     #[Route('/reports', name: 'app_reports')]
     public function index(): Response
     {
         return $this->render('report/index.html.twig');
     }
 
+    /**
+     * Provides a JSON API endpoint for fetching a user's service report data.
+     *
+     * @param VolunteerServiceRepository $volunteerServiceRepository The repository for volunteer-service associations.
+     * @param UserInterface $user The currently authenticated user.
+     * @return JsonResponse A JSON response containing the user's service history.
+     */
     #[Route('/api/user-report', name: 'app_user_report_api')]
     public function userReport(VolunteerServiceRepository $volunteerServiceRepository, UserInterface $user): JsonResponse
     {

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -14,8 +14,17 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Psr\Container\ContainerInterface;
 
+/**
+ * Controller handling security-related actions like login, logout, and access control.
+ */
 class SecurityController extends AbstractController
 {
+    /**
+     * Displays the login form and handles login errors.
+     *
+     * @param AuthenticationUtils $authenticationUtils Utility to get the last authentication error and username.
+     * @return Response The response object, rendering the login page.
+     */
     #[Route(path: '/login', name: 'app_login')]
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
@@ -32,6 +41,17 @@ class SecurityController extends AbstractController
         ]);
     }
 
+    /**
+     * Automatically logs in a user, intended for development environments only.
+     * This method bypasses the standard password authentication for quick access during development.
+     *
+     * @param Request $request The request object.
+     * @param User $user The user to log in.
+     * @param KernelInterface $kernel The application kernel to check the environment.
+     * @param ContainerInterface $container The service container to dispatch events.
+     * @return Response A redirection to the dashboard.
+     * @throws AccessDeniedHttpException If not in 'dev' environment or user is not an admin.
+     */
     public function autoLogin(Request $request, User $user, KernelInterface $kernel, ContainerInterface $container): Response
     {
         if ('dev' !== $kernel->getEnvironment()) {
@@ -51,12 +71,23 @@ class SecurityController extends AbstractController
         return $this->redirectToRoute('app_dashboard');
     }
 
+    /**
+     * Handles the logout process.
+     * This method is left blank as the logout functionality is intercepted by Symfony's security firewall.
+     *
+     * @throws \LogicException This exception is never thrown because the route is intercepted.
+     */
     #[Route(path: '/logout', name: 'app_logout')]
     public function logout(): void
     {
         throw new \LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
     }
 
+    /**
+     * Renders the access denied page.
+     *
+     * @return Response The response object, rendering the access denied page.
+     */
     #[Route('/access-denied', name: 'app_access_denied')]
     public function accessDenied(): Response
     {

--- a/src/Controller/VehicleController.php
+++ b/src/Controller/VehicleController.php
@@ -14,9 +14,18 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\String\Slugger\SluggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * Controller for managing vehicles in the admin panel.
+ */
 #[Route('/admin/vehicles')]
 class VehicleController extends AbstractController
 {
+    /**
+     * Displays a list of all vehicles.
+     *
+     * @param VehicleRepository $vehicleRepository The repository for vehicles.
+     * @return Response The response object.
+     */
     #[Route('/', name: 'app_vehicle_index', methods: ['GET'])]
     public function index(VehicleRepository $vehicleRepository): Response
     {
@@ -25,6 +34,15 @@ class VehicleController extends AbstractController
         ]);
     }
 
+    /**
+     * Creates a new vehicle.
+     * Handles photo uploads for the vehicle.
+     *
+     * @param Request $request The request object.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @param SluggerInterface $slugger The slugger to create safe filenames.
+     * @return Response The response object.
+     */
     #[Route('/new', name: 'app_vehicle_new', methods: ['GET', 'POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager, SluggerInterface $slugger): Response
     {
@@ -66,6 +84,12 @@ class VehicleController extends AbstractController
         ]);
     }
 
+    /**
+     * Displays the details of a specific vehicle.
+     *
+     * @param Vehicle $vehicle The vehicle to display.
+     * @return Response The response object.
+     */
     #[Route('/{id}', name: 'app_vehicle_show', methods: ['GET'])]
     public function show(Vehicle $vehicle): Response
     {
@@ -74,6 +98,17 @@ class VehicleController extends AbstractController
         ]);
     }
 
+    /**
+     * Edits an existing vehicle.
+     * Handles photo updates, including deleting the old photo.
+     *
+     * @param Request $request The request object.
+     * @param Vehicle $vehicle The vehicle to edit.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @param SluggerInterface $slugger The slugger to create safe filenames.
+     * @param Filesystem $filesystem The filesystem component to delete files.
+     * @return Response The response object.
+     */
     #[Route('/{id}/edit', name: 'app_vehicle_edit', methods: ['GET', 'POST'])]
     public function edit(Request $request, Vehicle $vehicle, EntityManagerInterface $entityManager, SluggerInterface $slugger, Filesystem $filesystem): Response
     {
@@ -119,6 +154,16 @@ class VehicleController extends AbstractController
         ]);
     }
 
+    /**
+     * Deletes a vehicle.
+     * Also deletes the associated photo from the filesystem.
+     *
+     * @param Request $request The request object.
+     * @param Vehicle $vehicle The vehicle to delete.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @param Filesystem $filesystem The filesystem component to delete files.
+     * @return Response The response object.
+     */
     #[Route('/{id}', name: 'app_vehicle_delete', methods: ['POST'])]
     public function delete(Request $request, Vehicle $vehicle, EntityManagerInterface $entityManager, Filesystem $filesystem): Response
     {
@@ -137,6 +182,14 @@ class VehicleController extends AbstractController
         return $this->redirectToRoute('app_vehicle_index', [], Response::HTTP_SEE_OTHER);
     }
 
+    /**
+     * Toggles the "out of service" status of a vehicle.
+     *
+     * @param Request $request The request object.
+     * @param Vehicle $vehicle The vehicle to update.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @return Response The response object.
+     */
     #[Route('/{id}/toggle-out-of-service', name: 'app_vehicle_toggle_out_of_service', methods: ['POST'])]
     public function toggleOutOfService(Request $request, Vehicle $vehicle, EntityManagerInterface $entityManager): Response
     {

--- a/src/Controller/VolunteerController.php
+++ b/src/Controller/VolunteerController.php
@@ -25,9 +25,20 @@ use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Knp\Component\Pager\PaginatorInterface; // ¡Importante!
 use Symfony\Component\Security\Http\Attribute\Security;
 
+/**
+ * Controller for managing volunteers, including listing, creation, editing, and reporting.
+ */
 // #[Route('/personal')] // Comentario de línea para la ruta '/personal'
 class VolunteerController extends AbstractController
 {
+    /**
+     * Displays a paginated list of volunteers with filtering and search capabilities.
+     *
+     * @param Request $request The request object to handle search and filter parameters.
+     * @param VolunteerRepository $volunteerRepository The repository for volunteers.
+     * @param PaginatorInterface $paginator The KNP Paginator service.
+     * @return Response The response object, rendering the volunteer list page.
+     */
     #[Route('/voluntarios', name: 'app_volunteer_list')]
     #[Security("is_granted('ROLE_ADMIN')")]
     // Inyecta PaginatorInterface para la paginación
@@ -92,6 +103,14 @@ class VolunteerController extends AbstractController
         ]);
     }
 
+    /**
+     * Handles the creation of a new volunteer by an administrator.
+     *
+     * @param Request $request The request object.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @param UserPasswordHasherInterface $userPasswordHasher The password hasher service.
+     * @return Response The response object, rendering the new volunteer form or redirecting on success.
+     */
     #[Route('/nuevo_voluntario', name: 'app_volunteer_new', methods: ['GET', 'POST'])]
     #[Security("is_granted('ROLE_ADMIN')")]
     public function new(Request $request, EntityManagerInterface $entityManager, UserPasswordHasherInterface $userPasswordHasher): Response
@@ -169,6 +188,15 @@ class VolunteerController extends AbstractController
         ]);
     }
 
+    /**
+     * Handles the public registration form for new volunteers.
+     * New registrations are set to a 'pending' status.
+     *
+     * @param Request $request The request object.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @param UserPasswordHasherInterface $userPasswordHasher The password hasher service.
+     * @return Response The response object, rendering the registration form or redirecting on success.
+     */
     #[Route('/nueva_inscripcion', name: 'app_volunteer_registration', methods: ['GET', 'POST'])]
     public function registration(Request $request, EntityManagerInterface $entityManager, UserPasswordHasherInterface $userPasswordHasher): Response
     {
@@ -250,6 +278,15 @@ class VolunteerController extends AbstractController
         ]);
     }
 
+    /**
+     * Handles the editing of an existing volunteer's profile.
+     *
+     * @param Request $request The request object.
+     * @param Volunteer $volunteer The volunteer entity to edit.
+     * @param EntityManagerInterface $entityManager The entity manager.
+     * @param UserPasswordHasherInterface $userPasswordHasher The password hasher service.
+     * @return Response The response object, rendering the edit form or redirecting on success.
+     */
     #[Route('/editar_voluntario-{id}', name: 'app_volunteer_edit', methods: ['GET', 'POST'])]
     #[Security("is_granted('ROLE_ADMIN')")]
     public function edit(Request $request, Volunteer $volunteer, EntityManagerInterface $entityManager, UserPasswordHasherInterface $userPasswordHasher): Response
@@ -320,6 +357,12 @@ class VolunteerController extends AbstractController
         ]);
     }
 
+    /**
+     * Exports all volunteer data to a CSV file.
+     *
+     * @param VolunteerRepository $volunteerRepository The repository for volunteers.
+     * @return Response A response object containing the CSV file for download.
+     */
     #[Route('/exportar-csv', name: 'app_volunteer_export_csv')]
     #[Security("is_granted('ROLE_ADMIN')")]
     public function exportCsv(VolunteerRepository $volunteerRepository): Response
@@ -368,6 +411,11 @@ class VolunteerController extends AbstractController
         return $response;
     }
 
+    /**
+     * Renders a "coming soon" page for volunteer reports.
+     *
+     * @return Response The response object.
+     */
     #[Route('/informes_voluntarios', name: 'app_volunteer_reports')]
     public function reports(): Response
     {
@@ -378,6 +426,14 @@ class VolunteerController extends AbstractController
         ]);
     }
 
+    /**
+     * Generates and displays a report of a specific volunteer's logged hours, with filtering options.
+     *
+     * @param Request $request The request object for filtering.
+     * @param Volunteer $volunteer The volunteer for whom the report is generated.
+     * @param FichajeRepository $fichajeRepository The repository for clock-in/out records.
+     * @return Response The response object, rendering the hours report page.
+     */
     #[Route('/{id}/informe-horas', name: 'app_volunteer_hours_report', methods: ['GET'])]
     public function hoursReport(Request $request, Volunteer $volunteer, FichajeRepository $fichajeRepository): Response
     {

--- a/src/Entity/AssistanceConfirmation.php
+++ b/src/Entity/AssistanceConfirmation.php
@@ -6,50 +6,92 @@ use App\Repository\AssistanceConfirmationRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
+/**
+ * Represents the confirmation of a volunteer's assistance for a specific service.
+ * It tracks whether a volunteer is attending, not attending, or on the reserve list.
+ */
 #[ORM\Entity(repositoryClass: AssistanceConfirmationRepository::class)]
 class AssistanceConfirmation
 {
+    /** @var string Status indicating the volunteer will attend the service. */
     public const STATUS_ATTENDING = 'attending';
+    /** @var string Status indicating the volunteer will not attend the service. */
     public const STATUS_NOT_ATTENDING = 'not_attending';
+    /** @var string Status indicating the volunteer is on the reserve list for the service. */
     public const STATUS_RESERVED = 'reserved';
 
+    /**
+     * @var int|null The unique identifier for the assistance confirmation.
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
+    /**
+     * @var string|null The status of the assistance (e.g., attending, not attending, reserved).
+     */
     #[ORM\Column(length: 255, options: ['default' => self::STATUS_NOT_ATTENDING])]
     private ?string $status = self::STATUS_NOT_ATTENDING;
 
+    /**
+     * @var Service|null The service associated with this confirmation.
+     */
     #[ORM\ManyToOne(inversedBy: 'assistanceConfirmations')]
     #[ORM\JoinColumn(nullable: false)]
     private ?Service $service = null;
 
+    /**
+     * @var Volunteer|null The volunteer associated with this confirmation.
+     */
     #[ORM\ManyToOne(inversedBy: 'assistanceConfirmations')]
     #[ORM\JoinColumn(nullable: false)]
     private ?Volunteer $volunteer = null;
 
+    /**
+     * @var \DateTimeInterface|null The timestamp when the confirmation was created.
+     */
     #[Gedmo\Timestampable(on: 'create')]
     #[ORM\Column(type: 'datetime')]
     private $createdAt;
 
+    /**
+     * @var \DateTimeInterface|null The timestamp when the confirmation was last updated.
+     */
     #[Gedmo\Timestampable(on: 'update')]
     #[ORM\Column(type: 'datetime')]
     private $updatedAt;
 
+    /**
+     * @var bool Indicates if the volunteer is responsible for clock-in/out records for this service.
+     */
     #[ORM\Column(type: 'boolean', options: ['default' => false])]
     private bool $isFichajeResponsible = false;
 
+    /**
+     * Gets the unique identifier for the assistance confirmation.
+     * @return int|null
+     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
+    /**
+     * Gets the status of the assistance.
+     * @return string|null
+     */
     public function getStatus(): ?string
     {
         return $this->status;
     }
 
+    /**
+     * Sets the status of the assistance.
+     * @param string $status The new status. Must be one of the STATUS_* constants.
+     * @return static
+     * @throws \InvalidArgumentException If the status is invalid.
+     */
     public function setStatus(string $status): static
     {
         if (!in_array($status, [self::STATUS_ATTENDING, self::STATUS_NOT_ATTENDING, self::STATUS_RESERVED])) {
@@ -60,11 +102,20 @@ class AssistanceConfirmation
         return $this;
     }
 
+    /**
+     * Gets the service associated with this confirmation.
+     * @return Service|null
+     */
     public function getService(): ?Service
     {
         return $this->service;
     }
 
+    /**
+     * Sets the service associated with this confirmation.
+     * @param Service|null $service The service.
+     * @return static
+     */
     public function setService(?Service $service): static
     {
         $this->service = $service;
@@ -72,11 +123,20 @@ class AssistanceConfirmation
         return $this;
     }
 
+    /**
+     * Gets the volunteer associated with this confirmation.
+     * @return Volunteer|null
+     */
     public function getVolunteer(): ?Volunteer
     {
         return $this->volunteer;
     }
 
+    /**
+     * Sets the volunteer associated with this confirmation.
+     * @param Volunteer|null $volunteer The volunteer.
+     * @return static
+     */
     public function setVolunteer(?Volunteer $volunteer): static
     {
         $this->volunteer = $volunteer;
@@ -84,21 +144,38 @@ class AssistanceConfirmation
         return $this;
     }
 
+    /**
+     * Gets the creation timestamp.
+     * @return \DateTimeInterface|null
+     */
     public function getCreatedAt()
     {
         return $this->createdAt;
     }
 
+    /**
+     * Gets the last update timestamp.
+     * @return \DateTimeInterface|null
+     */
     public function getUpdatedAt()
     {
         return $this->updatedAt;
     }
 
+    /**
+     * Checks if the volunteer is responsible for clock-in/out records.
+     * @return bool
+     */
     public function isFichajeResponsible(): bool
     {
         return $this->isFichajeResponsible;
     }
 
+    /**
+     * Sets whether the volunteer is responsible for clock-in/out records.
+     * @param bool $isFichajeResponsible True if the volunteer is responsible, false otherwise.
+     * @return static
+     */
     public function setFichajeResponsible(bool $isFichajeResponsible): static
     {
         $this->isFichajeResponsible = $isFichajeResponsible;
@@ -106,6 +183,10 @@ class AssistanceConfirmation
         return $this;
     }
 
+    /**
+     * Checks if the volunteer's status is 'attending'.
+     * @return bool True if the status is 'attending', false otherwise.
+     */
     public function hasAttended(): bool
     {
         return $this->status === self::STATUS_ATTENDING;

--- a/src/Entity/Fichaje.php
+++ b/src/Entity/Fichaje.php
@@ -6,37 +6,69 @@ use App\Repository\FichajeRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * Represents a clock-in/out record for a volunteer's participation in a service.
+ * Each `Fichaje` instance marks a single period of time a volunteer was active.
+ */
 #[ORM\Entity(repositoryClass: FichajeRepository::class)]
 class Fichaje
 {
+    /**
+     * @var int|null The unique identifier for the clock-in/out record.
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
+    /**
+     * @var VolunteerService|null The association between the volunteer and the service for this record.
+     */
     #[ORM\ManyToOne(inversedBy: 'fichajes')]
     #[ORM\JoinColumn(nullable: false)]
     private ?VolunteerService $volunteerService = null;
 
+    /**
+     * @var \DateTimeInterface|null The start time of the clock-in.
+     */
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     private ?\DateTimeInterface $startTime = null;
 
+    /**
+     * @var \DateTimeInterface|null The end time of the clock-out. Can be null if the volunteer is currently clocked in.
+     */
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $endTime = null;
 
+    /**
+     * @var string|null Optional notes for this specific clock-in/out period.
+     */
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $notes = null;
 
+    /**
+     * Gets the unique identifier for the clock-in/out record.
+     * @return int|null
+     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
+    /**
+     * Gets the associated volunteer-service link.
+     * @return VolunteerService|null
+     */
     public function getVolunteerService(): ?VolunteerService
     {
         return $this->volunteerService;
     }
 
+    /**
+     * Sets the associated volunteer-service link.
+     * @param VolunteerService|null $volunteerService The volunteer-service association.
+     * @return static
+     */
     public function setVolunteerService(?VolunteerService $volunteerService): static
     {
         $this->volunteerService = $volunteerService;
@@ -44,11 +76,20 @@ class Fichaje
         return $this;
     }
 
+    /**
+     * Gets the start time of the clock-in.
+     * @return \DateTimeInterface|null
+     */
     public function getStartTime(): ?\DateTimeInterface
     {
         return $this->startTime;
     }
 
+    /**
+     * Sets the start time of the clock-in.
+     * @param \DateTimeInterface $startTime The start time.
+     * @return static
+     */
     public function setStartTime(\DateTimeInterface $startTime): static
     {
         $this->startTime = $startTime;
@@ -56,11 +97,20 @@ class Fichaje
         return $this;
     }
 
+    /**
+     * Gets the end time of the clock-out.
+     * @return \DateTimeInterface|null
+     */
     public function getEndTime(): ?\DateTimeInterface
     {
         return $this->endTime;
     }
 
+    /**
+     * Sets the end time of the clock-out.
+     * @param \DateTimeInterface|null $endTime The end time.
+     * @return static
+     */
     public function setEndTime(?\DateTimeInterface $endTime): static
     {
         $this->endTime = $endTime;
@@ -68,11 +118,20 @@ class Fichaje
         return $this;
     }
 
+    /**
+     * Gets the notes for this record.
+     * @return string|null
+     */
     public function getNotes(): ?string
     {
         return $this->notes;
     }
 
+    /**
+     * Sets the notes for this record.
+     * @param string|null $notes The notes.
+     * @return static
+     */
     public function setNotes(?string $notes): static
     {
         $this->notes = $notes;

--- a/src/Entity/FuelType.php
+++ b/src/Entity/FuelType.php
@@ -7,35 +7,63 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * Represents a type of fuel that a vehicle can use (e.g., Diesel, Gasoline).
+ */
 #[ORM\Entity(repositoryClass: FuelTypeRepository::class)]
 class FuelType
 {
+    /**
+     * @var int|null The unique identifier for the fuel type.
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
+    /**
+     * @var string|null The name of the fuel type (e.g., "Diesel").
+     */
     #[ORM\Column(length: 255, unique: true)]
     private ?string $name = null;
 
+    /**
+     * @var Collection<int, Vehicle> A collection of vehicles that use this fuel type.
+     */
     #[ORM\OneToMany(mappedBy: 'fuelType', targetEntity: Vehicle::class)]
     private Collection $vehicles;
 
+    /**
+     * Initializes the vehicles collection.
+     */
     public function __construct()
     {
         $this->vehicles = new ArrayCollection();
     }
 
+    /**
+     * Gets the unique identifier for the fuel type.
+     * @return int|null
+     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
+    /**
+     * Gets the name of the fuel type.
+     * @return string|null
+     */
     public function getName(): ?string
     {
         return $this->name;
     }
 
+    /**
+     * Sets the name of the fuel type.
+     * @param string $name The new name.
+     * @return static
+     */
     public function setName(string $name): static
     {
         $this->name = $name;
@@ -44,6 +72,7 @@ class FuelType
     }
 
     /**
+     * Gets the collection of vehicles that use this fuel type.
      * @return Collection<int, Vehicle>
      */
     public function getVehicles(): Collection
@@ -51,6 +80,11 @@ class FuelType
         return $this->vehicles;
     }
 
+    /**
+     * Adds a vehicle to the collection of vehicles that use this fuel type.
+     * @param Vehicle $vehicle The vehicle to add.
+     * @return static
+     */
     public function addVehicle(Vehicle $vehicle): static
     {
         if (!$this->vehicles->contains($vehicle)) {
@@ -61,6 +95,11 @@ class FuelType
         return $this;
     }
 
+    /**
+     * Removes a vehicle from the collection of vehicles that use this fuel type.
+     * @param Vehicle $vehicle The vehicle to remove.
+     * @return static
+     */
     public function removeVehicle(Vehicle $vehicle): static
     {
         if ($this->vehicles->removeElement($vehicle)) {
@@ -73,6 +112,10 @@ class FuelType
         return $this;
     }
 
+    /**
+     * Returns the string representation of the fuel type, which is its name.
+     * @return string
+     */
     public function __toString(): string
     {
         return $this->name ?? '';

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -9,122 +9,232 @@ use Doctrine\DBal\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
+/**
+ * Represents a service or event that volunteers can attend.
+ * Contains all details about the service, such as date, time, location, and required resources.
+ */
 #[ORM\Entity(repositoryClass: ServiceRepository::class)]
 #[ORM\Table(name: 'service')]
 class Service
 {
+    /**
+     * @var int|null The unique identifier for the service.
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
+    /**
+     * @var string|null The official numeration or code for the service.
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $numeration = null;
 
+    /**
+     * @var string|null The title of the service.
+     */
     #[ORM\Column(length: 255)]
     private ?string $title = null;
 
+    /**
+     * @var string|null The URL-friendly slug generated from the title.
+     */
     #[Gedmo\Slug(fields: ['title'])]
     #[ORM\Column(length: 255, unique: true)]
     private ?string $slug = null;
 
+    /**
+     * @var \DateTimeInterface|null The start date and time of the service.
+     */
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     private ?\DateTimeInterface $startDate = null;
 
+    /**
+     * @var \DateTimeInterface|null The end date and time of the service.
+     */
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     private ?\DateTimeInterface $endDate = null;
 
+    /**
+     * @var \DateTimeInterface|null The deadline for volunteers to register for the service.
+     */
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $registrationLimitDate = null;
 
+    /**
+     * @var \DateTimeInterface|null The time volunteers are expected to be at the base.
+     */
     #[ORM\Column(type: Types::TIME_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $timeAtBase = null;
 
+    /**
+     * @var \DateTimeInterface|null The departure time from the base.
+     */
     #[ORM\Column(type: Types::TIME_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $departureTime = null;
 
+    /**
+     * @var int|null The maximum number of volunteers that can attend. Null for no limit.
+     */
     #[ORM\Column(type: Types::INTEGER, nullable: true)]
     private ?int $maxAttendees = null;
 
+    /**
+     * @var string|null The type of service (e.g., "Preventivo", "Emergencia").
+     */
     #[ORM\Column(length: 50, nullable: true)]
     private ?string $type = null;
 
+    /**
+     * @var string|null The category of the service (e.g., "Deportivo", "Cultural").
+     */
     #[ORM\Column(length: 50, nullable: true)]
     private ?string $category = null;
 
+    /**
+     * @var string|null A detailed description of the service.
+     */
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $description = null;
 
+    /**
+     * @var array|null The target audience or recipients of the service.
+     */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $recipients = null;
 
+    /**
+     * @var \DateTimeImmutable|null The timestamp when the service was created.
+     */
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     #[Gedmo\Timestampable(on: 'create')]
     private ?\DateTimeImmutable $createdAt = null;
 
+    /**
+     * @var \DateTimeImmutable|null The timestamp when the service was last updated.
+     */
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     #[Gedmo\Timestampable(on: 'update')]
     private ?\DateTimeImmutable $updatedAt = null;
 
+    /**
+     * @var bool Indicates if this service is in collaboration with other entities.
+     */
     #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
     private bool $collaborationWithOtherServices = false;
 
+    /**
+     * @var string|null The locality or city where the service takes place.
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $locality = null;
 
+    /**
+     * @var string|null The person or entity that requested the service.
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $requester = null;
 
+    /**
+     * @var Collection<int, AssistanceConfirmation> A collection of assistance confirmations for this service.
+     */
     #[ORM\OneToMany(mappedBy: 'service', targetEntity: AssistanceConfirmation::class, orphanRemoval: true)]
     #[ORM\OrderBy(['createdAt' => 'ASC'])]
     private Collection $assistanceConfirmations;
 
+    /**
+     * @var Collection<int, VolunteerService> A collection of volunteer-service associations.
+     */
     #[ORM\OneToMany(mappedBy: 'service', targetEntity: VolunteerService::class, orphanRemoval: true)]
     private Collection $volunteerServices;
 
+    /**
+     * @var string|null The expected affluence or crowd size.
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $afluencia = null;
 
+    /**
+     * @var int|null The number of Basic Life Support (SVB) units required.
+     */
     #[ORM\Column(nullable: true)]
     private ?int $numSvb = null;
 
+    /**
+     * @var int|null The number of Advanced Life Support (SVA) units required.
+     */
     #[ORM\Column(nullable: true)]
     private ?int $numSva = null;
 
+    /**
+     * @var int|null The number of Advanced Nursing Life Support (SVAE) units required.
+     */
     #[ORM\Column(nullable: true)]
     private ?int $numSvae = null;
 
+    /**
+     * @var int|null The number of doctors required.
+     */
     #[ORM\Column(nullable: true)]
     private ?int $numDoctors = null;
 
+    /**
+     * @var int|null The number of nurses required.
+     */
     #[ORM\Column(nullable: true)]
     private ?int $numNurses = null;
 
+    /**
+     * @var bool|null Indicates if a field hospital is required.
+     */
     #[ORM\Column(nullable: true)]
     private ?bool $hasFieldHospital = null;
 
+    /**
+     * @var string|null A description of the tasks to be performed by volunteers.
+     */
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $tasks = null;
 
+    /**
+     * @var bool|null Indicates if provisions (food, water) are provided.
+     */
     #[ORM\Column(nullable: true)]
     private ?bool $hasProvisions = null;
 
+    /**
+     * Initializes collections.
+     */
     public function __construct()
     {
         $this->assistanceConfirmations = new ArrayCollection();
         $this->volunteerServices = new ArrayCollection();
     }
 
+    /**
+     * Gets the unique identifier for the service.
+     * @return int|null
+     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
+    /**
+     * Gets the official numeration or code for the service.
+     * @return string|null
+     */
     public function getNumeration(): ?string
     {
         return $this->numeration;
     }
 
+    /**
+     * Sets the official numeration or code for the service.
+     * @param string|null $numeration The numeration code.
+     * @return static
+     */
     public function setNumeration(?string $numeration): static
     {
         $this->numeration = $numeration;
@@ -132,6 +242,7 @@ class Service
     }
 
     /**
+     * Gets the collection of volunteer-service associations.
      * @return Collection<int, VolunteerService>
      */
     public function getVolunteerServices(): Collection
@@ -139,6 +250,11 @@ class Service
         return $this->volunteerServices;
     }
 
+    /**
+     * Adds a volunteer-service association.
+     * @param VolunteerService $volunteerService The association to add.
+     * @return static
+     */
     public function addVolunteerService(VolunteerService $volunteerService): static
     {
         if (!$this->volunteerServices->contains($volunteerService)) {
@@ -149,6 +265,11 @@ class Service
         return $this;
     }
 
+    /**
+     * Removes a volunteer-service association.
+     * @param VolunteerService $volunteerService The association to remove.
+     * @return static
+     */
     public function removeVolunteerService(VolunteerService $volunteerService): static
     {
         if ($this->volunteerServices->removeElement($volunteerService)) {
@@ -161,165 +282,300 @@ class Service
         return $this;
     }
 
+    /**
+     * Gets the title of the service.
+     * @return string|null
+     */
     public function getTitle(): ?string
     {
         return $this->title;
     }
 
+    /**
+     * Sets the title of the service.
+     * @param string $title The title.
+     * @return static
+     */
     public function setTitle(string $title): static
     {
         $this->title = $title;
         return $this;
     }
 
+    /**
+     * Gets the URL-friendly slug.
+     * @return string|null
+     */
     public function getSlug(): ?string
     {
         return $this->slug;
     }
 
+    /**
+     * Sets the URL-friendly slug.
+     * @param string $slug The slug.
+     * @return static
+     */
     public function setSlug(string $slug): static
     {
         $this->slug = $slug;
         return $this;
     }
 
+    /**
+     * Gets the start date and time.
+     * @return \DateTimeInterface|null
+     */
     public function getStartDate(): ?\DateTimeInterface
     {
         return $this->startDate;
     }
 
+    /**
+     * Sets the start date and time.
+     * @param \DateTimeInterface $startDate The start date.
+     * @return static
+     */
     public function setStartDate(\DateTimeInterface $startDate): static
     {
         $this->startDate = $startDate;
         return $this;
     }
 
+    /**
+     * Gets the end date and time.
+     * @return \DateTimeInterface|null
+     */
     public function getEndDate(): ?\DateTimeInterface
     {
         return $this->endDate;
     }
 
+    /**
+     * Sets the end date and time.
+     * @param \DateTimeInterface $endDate The end date.
+     * @return static
+     */
     public function setEndDate(\DateTimeInterface $endDate): static
     {
         $this->endDate = $endDate;
         return $this;
     }
 
+    /**
+     * Gets the registration deadline.
+     * @return \DateTimeInterface|null
+     */
     public function getRegistrationLimitDate(): ?\DateTimeInterface
     {
         return $this->registrationLimitDate;
     }
 
+    /**
+     * Sets the registration deadline.
+     * @param \DateTimeInterface|null $registrationLimitDate The deadline.
+     * @return static
+     */
     public function setRegistrationLimitDate(?\DateTimeInterface $registrationLimitDate): static
     {
         $this->registrationLimitDate = $registrationLimitDate;
         return $this;
     }
 
+    /**
+     * Gets the time to be at the base.
+     * @return \DateTimeInterface|null
+     */
     public function getTimeAtBase(): ?\DateTimeInterface
     {
         return $this->timeAtBase;
     }
 
+    /**
+     * Sets the time to be at the base.
+     * @param \DateTimeInterface|null $timeAtBase The time.
+     * @return static
+     */
     public function setTimeAtBase(?\DateTimeInterface $timeAtBase): static
     {
         $this->timeAtBase = $timeAtBase;
         return $this;
     }
 
+    /**
+     * Gets the departure time.
+     * @return \DateTimeInterface|null
+     */
     public function getDepartureTime(): ?\DateTimeInterface
     {
         return $this->departureTime;
     }
 
+    /**
+     * Sets the departure time.
+     * @param \DateTimeInterface|null $departureTime The time.
+     * @return static
+     */
     public function setDepartureTime(?\DateTimeInterface $departureTime): static
     {
         $this->departureTime = $departureTime;
         return $this;
     }
 
+    /**
+     * Gets the maximum number of attendees.
+     * @return int|null
+     */
     public function getMaxAttendees(): ?int
     {
         return $this->maxAttendees;
     }
 
+    /**
+     * Sets the maximum number of attendees.
+     * @param int|null $maxAttendees The maximum number.
+     * @return static
+     */
     public function setMaxAttendees(?int $maxAttendees): static
     {
         $this->maxAttendees = $maxAttendees;
         return $this;
     }
 
+    /**
+     * Gets the type of service.
+     * @return string|null
+     */
     public function getType(): ?string
     {
         return $this->type;
     }
 
+    /**
+     * Sets the type of service.
+     * @param string|null $type The service type.
+     * @return static
+     */
     public function setType(?string $type): static
     {
         $this->type = $type;
         return $this;
     }
 
+    /**
+     * Gets the category of the service.
+     * @return string|null
+     */
     public function getCategory(): ?string
     {
         return $this->category;
     }
 
+    /**
+     * Sets the category of the service.
+     * @param string|null $category The service category.
+     * @return static
+     */
     public function setCategory(?string $category): static
     {
         $this->category = $category;
         return $this;
     }
 
+    /**
+     * Gets the description.
+     * @return string|null
+     */
     public function getDescription(): ?string
     {
         return $this->description;
     }
 
+    /**
+     * Sets the description.
+     * @param string|null $description The description.
+     * @return static
+     */
     public function setDescription(?string $description): static
     {
         $this->description = $description;
         return $this;
     }
 
+    /**
+     * Gets the target recipients.
+     * @return array|null
+     */
     public function getRecipients(): ?array
     {
         return $this->recipients;
     }
 
+    /**
+     * Sets the target recipients.
+     * @param array|null $recipients The recipients.
+     * @return static
+     */
     public function setRecipients(?array $recipients): static
     {
         $this->recipients = $recipients;
         return $this;
     }
 
+    /**
+     * Gets the creation timestamp.
+     * @return \DateTimeImmutable|null
+     */
     public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
 
+    /**
+     * Sets the creation timestamp.
+     * @param \DateTimeImmutable $createdAt The creation timestamp.
+     * @return static
+     */
     public function setCreatedAt(\DateTimeImmutable $createdAt): static
     {
         $this->createdAt = $createdAt;
         return $this;
     }
 
+    /**
+     * Gets the last update timestamp.
+     * @return \DateTimeImmutable|null
+     */
     public function getUpdatedAt(): ?\DateTimeImmutable
     {
         return $this->updatedAt;
     }
 
+    /**
+     * Sets the last update timestamp.
+     * @param \DateTimeImmutable $updatedAt The update timestamp.
+     * @return static
+     */
     public function setUpdatedAt(\DateTimeImmutable $updatedAt): static
     {
         $this->updatedAt = $updatedAt;
         return $this;
     }
 
+    /**
+     * Checks if the service involves collaboration.
+     * @return bool
+     */
     public function isCollaborationWithOtherServices(): bool
     {
         return $this->collaborationWithOtherServices;
     }
 
+    /**
+     * Sets whether the service involves collaboration.
+     * @param bool $collaborationWithOtherServices True if it involves collaboration.
+     * @return static
+     */
     public function setCollaborationWithOtherServices(bool $collaborationWithOtherServices): static
     {
         $this->collaborationWithOtherServices = $collaborationWithOtherServices;
@@ -327,22 +583,40 @@ class Service
         return $this;
     }
 
+    /**
+     * Gets the locality.
+     * @return string|null
+     */
     public function getLocality(): ?string
     {
         return $this->locality;
     }
 
+    /**
+     * Sets the locality.
+     * @param string|null $locality The locality.
+     * @return static
+     */
     public function setLocality(?string $locality): static
     {
         $this->locality = $locality;
         return $this;
     }
 
+    /**
+     * Gets the requester.
+     * @return string|null
+     */
     public function getRequester(): ?string
     {
         return $this->requester;
     }
 
+    /**
+     * Sets the requester.
+     * @param string|null $requester The requester.
+     * @return static
+     */
     public function setRequester(?string $requester): static
     {
         $this->requester = $requester;
@@ -350,6 +624,7 @@ class Service
     }
 
     /**
+     * Gets the collection of assistance confirmations.
      * @return Collection<int, AssistanceConfirmation>
      */
     public function getAssistanceConfirmations(): Collection
@@ -357,6 +632,11 @@ class Service
         return $this->assistanceConfirmations;
     }
 
+    /**
+     * Adds an assistance confirmation.
+     * @param AssistanceConfirmation $assistanceConfirmation The confirmation to add.
+     * @return static
+     */
     public function addAssistanceConfirmation(AssistanceConfirmation $assistanceConfirmation): static
     {
         if (!$this->assistanceConfirmations->contains($assistanceConfirmation)) {
@@ -367,6 +647,11 @@ class Service
         return $this;
     }
 
+    /**
+     * Removes an assistance confirmation.
+     * @param AssistanceConfirmation $assistanceConfirmation The confirmation to remove.
+     * @return static
+     */
     public function removeAssistanceConfirmation(AssistanceConfirmation $assistanceConfirmation): static
     {
         if ($this->assistanceConfirmations->removeElement($assistanceConfirmation)) {
@@ -379,11 +664,20 @@ class Service
         return $this;
     }
 
+    /**
+     * Gets the expected crowd size.
+     * @return string|null
+     */
     public function getAfluencia(): ?string
     {
         return $this->afluencia;
     }
 
+    /**
+     * Sets the expected crowd size.
+     * @param string|null $afluencia The crowd size.
+     * @return static
+     */
     public function setAfluencia(?string $afluencia): static
     {
         $this->afluencia = $afluencia;
@@ -391,11 +685,20 @@ class Service
         return $this;
     }
 
+    /**
+     * Gets the number of SVB units required.
+     * @return int|null
+     */
     public function getNumSvb(): ?int
     {
         return $this->numSvb;
     }
 
+    /**
+     * Sets the number of SVB units required.
+     * @param int|null $numSvb The number of units.
+     * @return static
+     */
     public function setNumSvb(?int $numSvb): static
     {
         $this->numSvb = $numSvb;
@@ -403,11 +706,20 @@ class Service
         return $this;
     }
 
+    /**
+     * Gets the number of SVA units required.
+     * @return int|null
+     */
     public function getNumSva(): ?int
     {
         return $this->numSva;
     }
 
+    /**
+     * Sets the number of SVA units required.
+     * @param int|null $numSva The number of units.
+     * @return static
+     */
     public function setNumSva(?int $numSva): static
     {
         $this->numSva = $numSva;
@@ -415,11 +727,20 @@ class Service
         return $this;
     }
 
+    /**
+     * Gets the number of SVAE units required.
+     * @return int|null
+     */
     public function getNumSvae(): ?int
     {
         return $this->numSvae;
     }
 
+    /**
+     * Sets the number of SVAE units required.
+     * @param int|null $numSvae The number of units.
+     * @return static
+     */
     public function setNumSvae(?int $numSvae): static
     {
         $this->numSvae = $numSvae;
@@ -427,11 +748,20 @@ class Service
         return $this;
     }
 
+    /**
+     * Gets the number of doctors required.
+     * @return int|null
+     */
     public function getNumDoctors(): ?int
     {
         return $this->numDoctors;
     }
 
+    /**
+     * Sets the number of doctors required.
+     * @param int|null $numDoctors The number of doctors.
+     * @return static
+     */
     public function setNumDoctors(?int $numDoctors): static
     {
         $this->numDoctors = $numDoctors;
@@ -439,11 +769,20 @@ class Service
         return $this;
     }
 
+    /**
+     * Gets the number of nurses required.
+     * @return int|null
+     */
     public function getNumNurses(): ?int
     {
         return $this->numNurses;
     }
 
+    /**
+     * Sets the number of nurses required.
+     * @param int|null $numNurses The number of nurses.
+     * @return static
+     */
     public function setNumNurses(?int $numNurses): static
     {
         $this->numNurses = $numNurses;
@@ -451,11 +790,20 @@ class Service
         return $this;
     }
 
+    /**
+     * Checks if a field hospital is required.
+     * @return bool|null
+     */
     public function isHasFieldHospital(): ?bool
     {
         return $this->hasFieldHospital;
     }
 
+    /**
+     * Sets whether a field hospital is required.
+     * @param bool|null $hasFieldHospital True if required.
+     * @return static
+     */
     public function setHasFieldHospital(?bool $hasFieldHospital): static
     {
         $this->hasFieldHospital = $hasFieldHospital;
@@ -463,11 +811,20 @@ class Service
         return $this;
     }
 
+    /**
+     * Gets the description of tasks.
+     * @return string|null
+     */
     public function getTasks(): ?string
     {
         return $this->tasks;
     }
 
+    /**
+     * Sets the description of tasks.
+     * @param string|null $tasks The tasks.
+     * @return static
+     */
     public function setTasks(?string $tasks): static
     {
         $this->tasks = $tasks;
@@ -475,11 +832,20 @@ class Service
         return $this;
     }
 
+    /**
+     * Checks if provisions are provided.
+     * @return bool|null
+     */
     public function isHasProvisions(): ?bool
     {
         return $this->hasProvisions;
     }
 
+    /**
+     * Sets whether provisions are provided.
+     * @param bool|null $hasProvisions True if provided.
+     * @return static
+     */
     public function setHasProvisions(?bool $hasProvisions): static
     {
         $this->hasProvisions = $hasProvisions;
@@ -487,14 +853,26 @@ class Service
         return $this;
     }
 
+    /**
+     * @var string|null The pre-generated WhatsApp message for sharing the service.
+     */
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $whatsappMessage = null;
 
+    /**
+     * Gets the WhatsApp message.
+     * @return string|null
+     */
     public function getWhatsappMessage(): ?string
     {
         return $this->whatsappMessage;
     }
 
+    /**
+     * Sets the WhatsApp message.
+     * @param string|null $whatsappMessage The message.
+     * @return static
+     */
     public function setWhatsappMessage(?string $whatsappMessage): static
     {
         $this->whatsappMessage = $whatsappMessage;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -11,42 +11,67 @@ use Symfony\Component\Security\Core\User\UserInterface;
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\Table(name: '`user`')]
 #[UniqueEntity(fields: ['email'], message: 'Ya existe una cuenta con este correo electrónico.')]
-
+/**
+ * Represents a user account in the system.
+ * This entity is used for authentication and authorization, and is linked to a volunteer profile.
+ */
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
+    /**
+     * @var int|null The unique identifier for the user.
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
+    /**
+     * @var string|null The user's email address, used as the login identifier.
+     */
     #[ORM\Column(length: 180, unique: true)]
     private ?string $email = null;
 
+    /**
+     * @var array The roles assigned to the user (e.g., ROLE_ADMIN, ROLE_VOLUNTEER).
+     */
     #[ORM\Column]
     private array $roles = [];
 
     /**
-     * @var string The hashed password
+     * @var string|null The hashed password for the user.
      */
     #[ORM\Column]
     private ?string $password = null;
 
-    // --- NUEVA RELACIÓN ONE-TO-ONE CON Volunteer ---
+    /**
+     * @var Volunteer|null The volunteer profile associated with this user account.
+     */
     #[ORM\OneToOne(mappedBy: 'user', cascade: ['persist', 'remove'])]
     private ?Volunteer $volunteer = null;
-    // ------------------------------------------
 
-
+    /**
+     * Gets the unique identifier for the user.
+     * @return int|null
+     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
+    /**
+     * Gets the user's email address.
+     * @return string|null
+     */
     public function getEmail(): ?string
     {
         return $this->email;
     }
 
+    /**
+     * Sets the user's email address.
+     * @param string $email The new email address.
+     * @return static
+     */
     public function setEmail(string $email): static
     {
         $this->email = $email;
@@ -58,6 +83,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      * A visual identifier that represents this user.
      *
      * @see UserInterface
+     * @return string The user's email address.
      */
     public function getUserIdentifier(): string
     {
@@ -65,7 +91,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
+     * Returns the roles granted to the user.
      * @see UserInterface
+     * @return array An array of roles.
      */
     public function getRoles(): array
     {
@@ -76,6 +104,11 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return array_unique($roles);
     }
 
+    /**
+     * Sets the roles for the user.
+     * @param array $roles The roles to set.
+     * @return static
+     */
     public function setRoles(array $roles): static
     {
         $this->roles = $roles;
@@ -84,13 +117,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
+     * Returns the hashed password for this user.
      * @see PasswordAuthenticatedUserInterface
+     * @return string The hashed password.
      */
     public function getPassword(): string
     {
         return $this->password;
     }
 
+    /**
+     * Sets the hashed password for the user.
+     * @param string $password The hashed password.
+     * @return static
+     */
     public function setPassword(string $password): static
     {
         $this->password = $password;
@@ -99,6 +139,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
+     * Removes sensitive data from the user.
      * @see UserInterface
      */
     public function eraseCredentials(): void
@@ -107,27 +148,32 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         // $this->plainPassword = null;\
     }
 
-    // --- GETTER Y SETTER PARA LA RELACIÓN VOLUNTEER (ACTUALIZADO) ---
+    /**
+     * Gets the associated volunteer profile.
+     * @return Volunteer|null
+     */
     public function getVolunteer(): ?Volunteer
     {
         return $this->volunteer;
     }
 
-    
-public function setVolunteer(?Volunteer $volunteer): static {
-    if ($this->volunteer === $volunteer) {
+    /**
+     * Sets the associated volunteer profile and maintains the bidirectional relationship.
+     * @param Volunteer|null $volunteer The volunteer profile.
+     * @return static
+     */
+    public function setVolunteer(?Volunteer $volunteer): static
+    {
+        if ($this->volunteer === $volunteer) {
+            return $this;
+        }
+
+        $this->volunteer = $volunteer;
+
+        if ($volunteer !== null && $volunteer->getUser() !== $this) {
+            $volunteer->setUser($this);
+        }
+
         return $this;
     }
-
-    $this->volunteer = $volunteer;
-
-    if ($volunteer !== null && $volunteer->getUser() !== $this) {
-        $volunteer->setUser($this);
-    }
-
-    return $this;
-}
-
-
-    // --------------------------------------------------
 }

--- a/src/Entity/Vehicle.php
+++ b/src/Entity/Vehicle.php
@@ -6,63 +6,122 @@ use App\Repository\VehicleRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * Represents a vehicle in the organization's fleet.
+ * Contains details about the vehicle, such as its make, model, license plate, and maintenance information.
+ */
 #[ORM\Entity(repositoryClass: VehicleRepository::class)]
 class Vehicle
 {
+    /**
+     * @var int|null The unique identifier for the vehicle.
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
+    /**
+     * @var string|null The manufacturer of the vehicle (e.g., "Ford").
+     */
     #[ORM\Column(length: 255)]
     private ?string $make = null;
 
+    /**
+     * @var string|null The model of the vehicle (e.g., "Transit").
+     */
     #[ORM\Column(length: 255)]
     private ?string $model = null;
 
+    /**
+     * @var string|null The license plate number of the vehicle. Must be unique.
+     */
     #[ORM\Column(length: 255, unique: true)]
     private ?string $licensePlate = null;
 
+    /**
+     * @var string|null The filename of the vehicle's photo.
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $photo = null;
 
+    /**
+     * @var string|null An alias or internal name for the vehicle.
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $alias = null;
 
+    /**
+     * @var \DateTimeInterface|null The date the vehicle was first registered.
+     */
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $registrationDate = null;
 
+    /**
+     * @var FuelType|null The type of fuel the vehicle uses.
+     */
     #[ORM\ManyToOne(inversedBy: 'vehicles')]
     private ?FuelType $fuelType = null;
 
+    /**
+     * @var string|null The type of vehicle (e.g., "Ambulance", "Car").
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $type = null;
 
+    /**
+     * @var \DateTimeInterface|null The date of the next scheduled technical revision.
+     */
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $nextRevisionDate = null;
 
+    /**
+     * @var \DateTimeInterface|null The due date for the vehicle's insurance.
+     */
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $insuranceDueDate = null;
 
+    /**
+     * @var string|null The type of cabin (e.g., "Simple", "Doble").
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $cabinType = null;
 
+    /**
+     * @var string|null A description of the resources or equipment available in the vehicle.
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $resources = null;
 
+    /**
+     * @var bool Indicates whether the vehicle is currently out of service.
+     */
     #[ORM\Column(type: 'boolean')]
     private bool $isOutOfService = false;
 
+    /**
+     * Gets the unique identifier for the vehicle.
+     * @return int|null
+     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
+    /**
+     * Gets the manufacturer of the vehicle.
+     * @return string|null
+     */
     public function getMake(): ?string
     {
         return $this->make;
     }
 
+    /**
+     * Sets the manufacturer of the vehicle.
+     * @param string $make The manufacturer.
+     * @return static
+     */
     public function setMake(string $make): static
     {
         $this->make = $make;
@@ -70,11 +129,20 @@ class Vehicle
         return $this;
     }
 
+    /**
+     * Gets the model of the vehicle.
+     * @return string|null
+     */
     public function getModel(): ?string
     {
         return $this->model;
     }
 
+    /**
+     * Sets the model of the vehicle.
+     * @param string $model The model.
+     * @return static
+     */
     public function setModel(string $model): static
     {
         $this->model = $model;
@@ -82,11 +150,20 @@ class Vehicle
         return $this;
     }
 
+    /**
+     * Gets the license plate number.
+     * @return string|null
+     */
     public function getLicensePlate(): ?string
     {
         return $this->licensePlate;
     }
 
+    /**
+     * Sets the license plate number.
+     * @param string $licensePlate The license plate number.
+     * @return static
+     */
     public function setLicensePlate(string $licensePlate): static
     {
         $this->licensePlate = $licensePlate;
@@ -94,11 +171,20 @@ class Vehicle
         return $this;
     }
 
+    /**
+     * Gets the filename of the vehicle's photo.
+     * @return string|null
+     */
     public function getPhoto(): ?string
     {
         return $this->photo;
     }
 
+    /**
+     * Sets the filename of the vehicle's photo.
+     * @param string|null $photo The photo filename.
+     * @return static
+     */
     public function setPhoto(?string $photo): static
     {
         $this->photo = $photo;
@@ -106,11 +192,20 @@ class Vehicle
         return $this;
     }
 
+    /**
+     * Gets the alias of the vehicle.
+     * @return string|null
+     */
     public function getAlias(): ?string
     {
         return $this->alias;
     }
 
+    /**
+     * Sets the alias of the vehicle.
+     * @param string|null $alias The alias.
+     * @return static
+     */
     public function setAlias(?string $alias): static
     {
         $this->alias = $alias;
@@ -118,11 +213,20 @@ class Vehicle
         return $this;
     }
 
+    /**
+     * Gets the registration date of the vehicle.
+     * @return \DateTimeInterface|null
+     */
     public function getRegistrationDate(): ?\DateTimeInterface
     {
         return $this->registrationDate;
     }
 
+    /**
+     * Sets the registration date of the vehicle.
+     * @param \DateTimeInterface|null $registrationDate The registration date.
+     * @return static
+     */
     public function setRegistrationDate(?\DateTimeInterface $registrationDate): static
     {
         $this->registrationDate = $registrationDate;
@@ -130,11 +234,20 @@ class Vehicle
         return $this;
     }
 
+    /**
+     * Gets the fuel type of the vehicle.
+     * @return FuelType|null
+     */
     public function getFuelType(): ?FuelType
     {
         return $this->fuelType;
     }
 
+    /**
+     * Sets the fuel type of the vehicle.
+     * @param FuelType|null $fuelType The fuel type.
+     * @return static
+     */
     public function setFuelType(?FuelType $fuelType): static
     {
         $this->fuelType = $fuelType;
@@ -142,11 +255,20 @@ class Vehicle
         return $this;
     }
 
+    /**
+     * Gets the type of the vehicle.
+     * @return string|null
+     */
     public function getType(): ?string
     {
         return $this->type;
     }
 
+    /**
+     * Sets the type of the vehicle.
+     * @param string|null $type The vehicle type.
+     * @return static
+     */
     public function setType(?string $type): static
     {
         $this->type = $type;
@@ -154,11 +276,20 @@ class Vehicle
         return $this;
     }
 
+    /**
+     * Gets the next revision date.
+     * @return \DateTimeInterface|null
+     */
     public function getNextRevisionDate(): ?\DateTimeInterface
     {
         return $this->nextRevisionDate;
     }
 
+    /**
+     * Sets the next revision date.
+     * @param \DateTimeInterface|null $nextRevisionDate The next revision date.
+     * @return static
+     */
     public function setNextRevisionDate(?\DateTimeInterface $nextRevisionDate): static
     {
         $this->nextRevisionDate = $nextRevisionDate;
@@ -166,11 +297,20 @@ class Vehicle
         return $this;
     }
 
+    /**
+     * Gets the insurance due date.
+     * @return \DateTimeInterface|null
+     */
     public function getInsuranceDueDate(): ?\DateTimeInterface
     {
         return $this->insuranceDueDate;
     }
 
+    /**
+     * Sets the insurance due date.
+     * @param \DateTimeInterface|null $insuranceDueDate The insurance due date.
+     * @return static
+     */
     public function setInsuranceDueDate(?\DateTimeInterface $insuranceDueDate): static
     {
         $this->insuranceDueDate = $insuranceDueDate;
@@ -178,11 +318,20 @@ class Vehicle
         return $this;
     }
 
+    /**
+     * Gets the cabin type.
+     * @return string|null
+     */
     public function getCabinType(): ?string
     {
         return $this->cabinType;
     }
 
+    /**
+     * Sets the cabin type.
+     * @param string|null $cabinType The cabin type.
+     * @return static
+     */
     public function setCabinType(?string $cabinType): static
     {
         $this->cabinType = $cabinType;
@@ -190,11 +339,20 @@ class Vehicle
         return $this;
     }
 
+    /**
+     * Gets the resources available in the vehicle.
+     * @return string|null
+     */
     public function getResources(): ?string
     {
         return $this->resources;
     }
 
+    /**
+     * Sets the resources available in the vehicle.
+     * @param string|null $resources The resources.
+     * @return static
+     */
     public function setResources(?string $resources): static
     {
         $this->resources = $resources;
@@ -202,11 +360,20 @@ class Vehicle
         return $this;
     }
 
+    /**
+     * Checks if the vehicle is out of service.
+     * @return bool
+     */
     public function isOutOfService(): bool
     {
         return $this->isOutOfService;
     }
 
+    /**
+     * Sets the out-of-service status of the vehicle.
+     * @param bool $isOutOfService True if the vehicle is out of service.
+     * @return static
+     */
     public function setOutOfService(bool $isOutOfService): static
     {
         $this->isOutOfService = $isOutOfService;

--- a/src/Entity/Volunteer.php
+++ b/src/Entity/Volunteer.php
@@ -8,501 +8,922 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\DBal\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * Represents a volunteer's profile, containing personal information, qualifications, and status.
+ * This entity is linked to a User account for authentication.
+ */
 #[ORM\Entity(repositoryClass: VolunteerRepository::class)]
 class Volunteer
 {
+    /** @var string Status for an active volunteer. */
     public const STATUS_ACTIVE = 'Activo';
+    /** @var string Status for a suspended volunteer. */
     public const STATUS_SUSPENDED = 'Suspensión';
+    /** @var string Status for an inactive (resigned) volunteer. */
     public const STATUS_INACTIVE = 'Baja';
+    /** @var string Status for a new registration pending approval. */
     public const STATUS_PENDING = 'pending';
 
+    /**
+     * @var int|null The unique identifier for the volunteer.
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
+    /**
+     * @var string|null The first name of the volunteer.
+     */
     #[ORM\Column(length: 255)]
     private ?string $name = null;
 
+    /**
+     * @var string|null The last name of the volunteer.
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $lastName = null;
 
+    /**
+     * @var string|null The phone number of the volunteer.
+     */
     #[ORM\Column(length: 20)]
     private ?string $phone = null;
 
+    /**
+     * @var string|null The DNI (National Identity Document) of the volunteer. Must be unique.
+     */
     #[ORM\Column(length: 15, unique: true, nullable: true)]
     private ?string $dni = null;
 
+    /**
+     * @var \DateTimeInterface|null The date of birth of the volunteer.
+     */
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $dateOfBirth = null;
 
+    /**
+     * @var string|null The type of street for the address (e.g., "Calle", "Avenida").
+     */
     #[ORM\Column(length: 50, nullable: true)]
     private ?string $streetType = null;
 
+    /**
+     * @var string|null The main address line.
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $address = null;
 
+    /**
+     * @var string|null The postal code.
+     */
     #[ORM\Column(length: 10, nullable: true)]
     private ?string $postalCode = null;
 
+    /**
+     * @var string|null The province.
+     */
     #[ORM\Column(length: 100, nullable: true)]
     private ?string $province = null;
 
+    /**
+     * @var string|null The city.
+     */
     #[ORM\Column(length: 100, nullable: true)]
     private ?string $city = null;
 
+    /**
+     * @var string|null The name of the primary emergency contact.
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $contactPerson1 = null;
 
+    /**
+     * @var string|null The phone number of the primary emergency contact.
+     */
     #[ORM\Column(length: 20, nullable: true)]
     private ?string $contactPhone1 = null;
 
+    /**
+     * @var string|null The name of the secondary emergency contact.
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $contactPerson2 = null;
 
+    /**
+     * @var string|null The phone number of the secondary emergency contact.
+     */
     #[ORM\Column(length: 20, nullable: true)]
     private ?string $contactPhone2 = null;
 
+    /**
+     * @var string|null Information about any allergies the volunteer has.
+     */
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $allergies = null;
 
+    /**
+     * @var string|null The volunteer's profession.
+     */
     #[ORM\Column(length: 100, nullable: true)]
     private ?string $profession = null;
 
+    /**
+     * @var string|null The volunteer's current employment status.
+     */
     #[ORM\Column(length: 100, nullable: true)]
     private ?string $employmentStatus = null;
 
+    /**
+     * @var array|null An array of driving licenses the volunteer holds.
+     */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $drivingLicenses = null;
 
+    /**
+     * @var \DateTimeInterface|null The expiry date of the driving license.
+     */
     #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $drivingLicenseExpiryDate = null;
 
+    /**
+     * @var string|null Languages spoken by the volunteer.
+     */
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $languages = null;
 
+    /**
+     * @var string|null The volunteer's motivation for joining.
+     */
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $motivation = null;
 
+    /**
+     * @var string|null How the volunteer heard about the organization.
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $howKnown = null;
 
+    /**
+     * @var bool|null Whether the volunteer has prior volunteering experience.
+     */
     #[ORM\Column(type: Types::BOOLEAN, nullable: true)]
     private ?bool $hasVolunteeredBefore = null;
 
+    /**
+     * @var string|null Names of institutions where the volunteer has previously volunteered.
+     */
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $previousVolunteeringInstitutions = null;
 
+    /**
+     * @var string|null Other relevant qualifications or skills.
+     */
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $otherQualifications = null;
 
+    /**
+     * @var array|null An array of navigation licenses the volunteer holds.
+     */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $navigationLicenses = null;
 
+    /**
+     * @var array|null An array of specific, certified qualifications.
+     */
     #[ORM\Column(type: Types::JSON, nullable: true)]
     private ?array $specificQualifications = null;
 
+    /**
+     * @var string|null The role of the volunteer within the organization (e.g., "Jefe de Unidad").
+     */
     #[ORM\Column(length: 100)]
     private ?string $role = null;
 
+    /**
+     * @var string|null The current status of the volunteer (e.g., "Activo", "Baja").
+     */
     #[ORM\Column(length: 20)]
     private ?string $status = self::STATUS_ACTIVE;
 
+    /**
+     * @var \DateTimeInterface|null The date the volunteer joined the organization.
+     */
     #[ORM\Column(type: 'datetime')]
     private ?\DateTimeInterface $joinDate = null;
 
+    /**
+     * @var string|null The specialization of the volunteer (e.g., "Sanitario", "Logística").
+     */
     #[ORM\Column(length: 255)]
     private ?string $specialization = null;
 
+    /**
+     * @var User|null The User entity associated with this volunteer profile.
+     */
     #[ORM\OneToOne(inversedBy: 'volunteer', cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: false)]
     private ?User $user = null;
 
+    /**
+     * @var string|null The filename of the volunteer's profile picture.
+     */
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $profilePicture = null;
 
+    /**
+     * @var Collection<int, AssistanceConfirmation> A collection of this volunteer's assistance confirmations.
+     */
     #[ORM\OneToMany(mappedBy: 'volunteer', targetEntity: AssistanceConfirmation::class)]
     private Collection $assistanceConfirmations;
 
+    /**
+     * @var Collection<int, VolunteerService> A collection of this volunteer's service participation records.
+     */
     #[ORM\OneToMany(mappedBy: 'volunteer', targetEntity: VolunteerService::class)]
     private Collection $volunteerServices;
 
+    /**
+     * Initializes collections.
+     */
     public function __construct()
     {
         $this->assistanceConfirmations = new ArrayCollection();
         $this->volunteerServices = new ArrayCollection();
     }
 
+    /**
+     * Gets the unique identifier for the volunteer.
+     * @return int|null
+     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
+    /**
+     * Gets the first name of the volunteer.
+     * @return string|null
+     */
     public function getName(): ?string
     {
         return $this->name;
     }
 
+    /**
+     * Sets the first name of the volunteer.
+     * @param string $name The first name.
+     * @return static
+     */
     public function setName(string $name): static
     {
         $this->name = $name;
         return $this;
     }
 
+    /**
+     * Gets the last name of the volunteer.
+     * @return string|null
+     */
     public function getLastName(): ?string
     {
         return $this->lastName;
     }
 
+    /**
+     * Sets the last name of the volunteer.
+     * @param string|null $lastName The last name.
+     * @return static
+     */
     public function setLastName(?string $lastName): static
     {
         $this->lastName = $lastName;
         return $this;
     }
 
+    /**
+     * Gets the phone number of the volunteer.
+     * @return string|null
+     */
     public function getPhone(): ?string
     {
         return $this->phone;
     }
 
+    /**
+     * Sets the phone number of the volunteer.
+     * @param string $phone The phone number.
+     * @return static
+     */
     public function setPhone(string $phone): static
     {
         $this->phone = $phone;
         return $this;
     }
 
+    /**
+     * Gets the DNI of the volunteer.
+     * @return string|null
+     */
     public function getDni(): ?string
     {
         return $this->dni;
     }
 
+    /**
+     * Sets the DNI of the volunteer.
+     * @param string|null $dni The DNI.
+     * @return static
+     */
     public function setDni(?string $dni): static
     {
         $this->dni = $dni;
         return $this;
     }
 
+    /**
+     * Gets the date of birth of the volunteer.
+     * @return \DateTimeInterface|null
+     */
     public function getDateOfBirth(): ?\DateTimeInterface
     {
         return $this->dateOfBirth;
     }
 
+    /**
+     * Sets the date of birth of the volunteer.
+     * @param \DateTimeInterface|null $dateOfBirth The date of birth.
+     * @return static
+     */
     public function setDateOfBirth(?\DateTimeInterface $dateOfBirth): static
     {
         $this->dateOfBirth = $dateOfBirth;
         return $this;
     }
 
+    /**
+     * Gets the street type for the address.
+     * @return string|null
+     */
     public function getStreetType(): ?string
     {
         return $this->streetType;
     }
 
+    /**
+     * Sets the street type for the address.
+     * @param string|null $streetType The street type.
+     * @return static
+     */
     public function setStreetType(?string $streetType): static
     {
         $this->streetType = $streetType;
         return $this;
     }
 
+    /**
+     * Gets the address.
+     * @return string|null
+     */
     public function getAddress(): ?string
     {
         return $this->address;
     }
 
+    /**
+     * Sets the address.
+     * @param string|null $address The address.
+     * @return static
+     */
     public function setAddress(?string $address): static
     {
         $this->address = $address;
         return $this;
     }
 
+    /**
+     * Gets the postal code.
+     * @return string|null
+     */
     public function getPostalCode(): ?string
     {
         return $this->postalCode;
     }
 
+    /**
+     * Sets the postal code.
+     * @param string|null $postalCode The postal code.
+     * @return static
+     */
     public function setPostalCode(?string $postalCode): static
     {
         $this->postalCode = $postalCode;
         return $this;
     }
 
+    /**
+     * Gets the province.
+     * @return string|null
+     */
     public function getProvince(): ?string
     {
         return $this->province;
     }
 
+    /**
+     * Sets the province.
+     * @param string|null $province The province.
+     * @return static
+     */
     public function setProvince(?string $province): static
     {
         $this->province = $province;
         return $this;
     }
 
+    /**
+     * Gets the city.
+     * @return string|null
+     */
     public function getCity(): ?string
     {
         return $this->city;
     }
 
+    /**
+     * Sets the city.
+     * @param string|null $city The city.
+     * @return static
+     */
     public function setCity(?string $city): static
     {
         $this->city = $city;
         return $this;
     }
 
+    /**
+     * Gets the primary emergency contact person's name.
+     * @return string|null
+     */
     public function getContactPerson1(): ?string
     {
         return $this->contactPerson1;
     }
 
+    /**
+     * Sets the primary emergency contact person's name.
+     * @param string|null $contactPerson1 The contact's name.
+     * @return static
+     */
     public function setContactPerson1(?string $contactPerson1): static
     {
         $this->contactPerson1 = $contactPerson1;
         return $this;
     }
 
+    /**
+     * Gets the primary emergency contact person's phone number.
+     * @return string|null
+     */
     public function getContactPhone1(): ?string
     {
         return $this->contactPhone1;
     }
 
+    /**
+     * Sets the primary emergency contact person's phone number.
+     * @param string|null $contactPhone1 The contact's phone number.
+     * @return static
+     */
     public function setContactPhone1(?string $contactPhone1): static
     {
         $this->contactPhone1 = $contactPhone1;
         return $this;
     }
 
+    /**
+     * Gets the secondary emergency contact person's name.
+     * @return string|null
+     */
     public function getContactPerson2(): ?string
     {
         return $this->contactPerson2;
     }
 
+    /**
+     * Sets the secondary emergency contact person's name.
+     * @param string|null $contactPerson2 The contact's name.
+     * @return static
+     */
     public function setContactPerson2(?string $contactPerson2): static
     {
         $this->contactPerson2 = $contactPerson2;
         return $this;
     }
 
+    /**
+     * Gets the secondary emergency contact person's phone number.
+     * @return string|null
+     */
     public function getContactPhone2(): ?string
     {
         return $this->contactPhone2;
     }
 
+    /**
+     * Sets the secondary emergency contact person's phone number.
+     * @param string|null $contactPhone2 The contact's phone number.
+     * @return static
+     */
     public function setContactPhone2(?string $contactPhone2): static
     {
         $this->contactPhone2 = $contactPhone2;
         return $this;
     }
 
+    /**
+     * Gets information about allergies.
+     * @return string|null
+     */
     public function getAllergies(): ?string
     {
         return $this->allergies;
     }
 
+    /**
+     * Sets information about allergies.
+     * @param string|null $allergies The allergy information.
+     * @return static
+     */
     public function setAllergies(?string $allergies): static
     {
         $this->allergies = $allergies;
         return $this;
     }
 
+    /**
+     * Gets the volunteer's profession.
+     * @return string|null
+     */
     public function getProfession(): ?string
     {
         return $this->profession;
     }
 
+    /**
+     * Sets the volunteer's profession.
+     * @param string|null $profession The profession.
+     * @return static
+     */
     public function setProfession(?string $profession): static
     {
         $this->profession = $profession;
         return $this;
     }
 
+    /**
+     * Gets the volunteer's employment status.
+     * @return string|null
+     */
     public function getEmploymentStatus(): ?string
     {
         return $this->employmentStatus;
     }
 
+    /**
+     * Sets the volunteer's employment status.
+     * @param string|null $employmentStatus The employment status.
+     * @return static
+     */
     public function setEmploymentStatus(?string $employmentStatus): static
     {
         $this->employmentStatus = $employmentStatus;
         return $this;
     }
 
+    /**
+     * Gets the driving licenses held by the volunteer.
+     * @return array
+     */
     public function getDrivingLicenses(): array
     {
         return $this->drivingLicenses ?? [];
     }
 
+    /**
+     * Sets the driving licenses held by the volunteer.
+     * @param array|null $drivingLicenses An array of licenses.
+     * @return static
+     */
     public function setDrivingLicenses(?array $drivingLicenses): static
     {
         $this->drivingLicenses = $drivingLicenses;
         return $this;
     }
 
+    /**
+     * Gets the expiry date of the driving license.
+     * @return \DateTimeInterface|null
+     */
     public function getDrivingLicenseExpiryDate(): ?\DateTimeInterface
     {
         return $this->drivingLicenseExpiryDate;
     }
 
+    /**
+     * Sets the expiry date of the driving license.
+     * @param \DateTimeInterface|null $drivingLicenseExpiryDate The expiry date.
+     * @return static
+     */
     public function setDrivingLicenseExpiryDate(?\DateTimeInterface $drivingLicenseExpiryDate): static
     {
         $this->drivingLicenseExpiryDate = $drivingLicenseExpiryDate;
         return $this;
     }
 
+    /**
+     * Gets the languages spoken by the volunteer.
+     * @return string|null
+     */
     public function getLanguages(): ?string
     {
         return $this->languages;
     }
 
+    /**
+     * Sets the languages spoken by the volunteer.
+     * @param string|null $languages The languages.
+     * @return static
+     */
     public function setLanguages(?string $languages): static
     {
         $this->languages = $languages;
         return $this;
     }
 
+    /**
+     * Gets the volunteer's motivation for joining.
+     * @return string|null
+     */
     public function getMotivation(): ?string
     {
         return $this->motivation;
     }
 
+    /**
+     * Sets the volunteer's motivation for joining.
+     * @param string|null $motivation The motivation text.
+     * @return static
+     */
     public function setMotivation(?string $motivation): static
     {
         $this->motivation = $motivation;
         return $this;
     }
 
+    /**
+     * Gets how the volunteer heard about the organization.
+     * @return string|null
+     */
     public function getHowKnown(): ?string
     {
         return $this->howKnown;
     }
 
+    /**
+     * Sets how the volunteer heard about the organization.
+     * @param string|null $howKnown The source.
+     * @return static
+     */
     public function setHowKnown(?string $howKnown): static
     {
         $this->howKnown = $howKnown;
         return $this;
     }
 
+    /**
+     * Checks if the volunteer has prior volunteering experience.
+     * @return bool|null
+     */
     public function getHasVolunteeredBefore(): ?bool
     {
         return $this->hasVolunteeredBefore;
     }
 
+    /**
+     * Sets whether the volunteer has prior volunteering experience.
+     * @param bool|null $hasVolunteeredBefore True if they have experience.
+     * @return static
+     */
     public function setHasVolunteeredBefore(?bool $hasVolunteeredBefore): static
     {
         $this->hasVolunteeredBefore = $hasVolunteeredBefore;
         return $this;
     }
 
+    /**
+     * Gets the names of institutions where the volunteer has previously volunteered.
+     * @return string|null
+     */
     public function getPreviousVolunteeringInstitutions(): ?string
     {
         return $this->previousVolunteeringInstitutions;
     }
 
+    /**
+     * Sets the names of institutions where the volunteer has previously volunteered.
+     * @param string|null $previousVolunteeringInstitutions The names of institutions.
+     * @return static
+     */
     public function setPreviousVolunteeringInstitutions(?string $previousVolunteeringInstitutions): static
     {
         $this->previousVolunteeringInstitutions = $previousVolunteeringInstitutions;
         return $this;
     }
 
+    /**
+     * Gets other relevant qualifications.
+     * @return string|null
+     */
     public function getOtherQualifications(): ?string
     {
         return $this->otherQualifications;
     }
 
+    /**
+     * Sets other relevant qualifications.
+     * @param string|null $otherQualifications The qualifications.
+     * @return static
+     */
     public function setOtherQualifications(?string $otherQualifications): static
     {
         $this->otherQualifications = $otherQualifications;
         return $this;
     }
 
+    /**
+     * Gets the navigation licenses held by the volunteer.
+     * @return array
+     */
     public function getNavigationLicenses(): array
     {
         return $this->navigationLicenses ?? [];
     }
 
+    /**
+     * Sets the navigation licenses held by the volunteer.
+     * @param array|null $navigationLicenses An array of licenses.
+     * @return static
+     */
     public function setNavigationLicenses(?array $navigationLicenses): static
     {
         $this->navigationLicenses = $navigationLicenses;
         return $this;
     }
 
+    /**
+     * Gets specific, certified qualifications.
+     * @return array
+     */
     public function getSpecificQualifications(): array
     {
         return $this->specificQualifications ?? [];
     }
 
+    /**
+     * Sets specific, certified qualifications.
+     * @param array|null $specificQualifications An array of qualifications.
+     * @return static
+     */
     public function setSpecificQualifications(?array $specificQualifications): static
     {
         $this->specificQualifications = $specificQualifications;
         return $this;
     }
 
+    /**
+     * Gets the role of the volunteer.
+     * @return string|null
+     */
     public function getRole(): ?string
     {
         return $this->role;
     }
 
+    /**
+     * Sets the role of the volunteer.
+     * @param string $role The role.
+     * @return static
+     */
     public function setRole(string $role): static
     {
         $this->role = $role;
         return $this;
     }
 
+    /**
+     * Gets the current status of the volunteer.
+     * @return string|null
+     */
     public function getStatus(): ?string
     {
         return $this->status;
     }
 
+    /**
+     * Sets the current status of the volunteer.
+     * @param string $status The new status.
+     * @return static
+     */
     public function setStatus(string $status): static
     {
         $this->status = $status;
         return $this;
     }
 
+    /**
+     * Gets the date the volunteer joined.
+     * @return \DateTimeInterface|null
+     */
     public function getJoinDate(): ?\DateTimeInterface
     {
         return $this->joinDate;
     }
 
+    /**
+     * Sets the date the volunteer joined.
+     * @param \DateTimeInterface $joinDate The join date.
+     * @return static
+     */
     public function setJoinDate(\DateTimeInterface $joinDate): static
     {
         $this->joinDate = $joinDate;
         return $this;
     }
 
+    /**
+     * Gets the specialization of the volunteer.
+     * @return string|null
+     */
     public function getSpecialization(): ?string
     {
         return $this->specialization;
     }
 
+    /**
+     * Sets the specialization of the volunteer.
+     * @param string $specialization The specialization.
+     * @return static
+     */
     public function setSpecialization(string $specialization): static
     {
         $this->specialization = $specialization;
         return $this;
     }
 
+    /**
+     * Gets the associated User entity.
+     * @return User|null
+     */
     public function getUser(): ?User
     {
         return $this->user;
     }
 
-   public function setUser(?User $user): static {
-    if ($this->user === $user) {
+    /**
+     * Sets the associated User entity and maintains the bidirectional relationship.
+     * @param User|null $user The User entity.
+     * @return static
+     */
+    public function setUser(?User $user): static
+    {
+        if ($this->user === $user) {
+            return $this;
+        }
+
+        $this->user = $user;
+
+        if ($user !== null && $user->getVolunteer() !== $this) {
+            $user->setVolunteer($this);
+        }
+
         return $this;
     }
 
-    $this->user = $user;
-
-    if ($user !== null && $user->getVolunteer() !== $this) {
-        $user->setVolunteer($this);
-    }
-
-    return $this;
-}
-
+    /**
+     * Gets the filename of the profile picture.
+     * @return string|null
+     */
     public function getProfilePicture(): ?string
     {
         return $this->profilePicture;
     }
 
+    /**
+     * Sets the filename of the profile picture.
+     * @param string|null $profilePicture The filename.
+     * @return static
+     */
     public function setProfilePicture(?string $profilePicture): static
     {
         $this->profilePicture = $profilePicture;
@@ -511,6 +932,7 @@ class Volunteer
     }
 
     /**
+     * Gets the collection of assistance confirmations for this volunteer.
      * @return Collection<int, AssistanceConfirmation>
      */
     public function getAssistanceConfirmations(): Collection
@@ -518,6 +940,11 @@ class Volunteer
         return $this->assistanceConfirmations;
     }
 
+    /**
+     * Adds an assistance confirmation for this volunteer.
+     * @param AssistanceConfirmation $assistanceConfirmation The confirmation to add.
+     * @return static
+     */
     public function addAssistanceConfirmation(AssistanceConfirmation $assistanceConfirmation): static
     {
         if (!$this->assistanceConfirmations->contains($assistanceConfirmation)) {
@@ -528,6 +955,11 @@ class Volunteer
         return $this;
     }
 
+    /**
+     * Removes an assistance confirmation for this volunteer.
+     * @param AssistanceConfirmation $assistanceConfirmation The confirmation to remove.
+     * @return static
+     */
     public function removeAssistanceConfirmation(AssistanceConfirmation $assistanceConfirmation): static
     {
         if ($this->assistanceConfirmations->removeElement($assistanceConfirmation)) {
@@ -541,6 +973,7 @@ class Volunteer
     }
 
     /**
+     * Gets the collection of service participation records for this volunteer.
      * @return Collection<int, VolunteerService>
      */
     public function getVolunteerServices(): Collection
@@ -548,6 +981,11 @@ class Volunteer
         return $this->volunteerServices;
     }
 
+    /**
+     * Adds a service participation record for this volunteer.
+     * @param VolunteerService $volunteerService The record to add.
+     * @return static
+     */
     public function addVolunteerService(VolunteerService $volunteerService): static
     {
         if (!$this->volunteerServices->contains($volunteerService)) {
@@ -558,6 +996,11 @@ class Volunteer
         return $this;
     }
 
+    /**
+     * Removes a service participation record for this volunteer.
+     * @param VolunteerService $volunteerService The record to remove.
+     * @return static
+     */
     public function removeVolunteerService(VolunteerService $volunteerService): static
     {
         if ($this->volunteerServices->removeElement($volunteerService)) {
@@ -570,6 +1013,11 @@ class Volunteer
         return $this;
     }
 
+    /**
+     * Finds the specific VolunteerService record for a given Service.
+     * @param Service $service The service to find the record for.
+     * @return VolunteerService|null The corresponding VolunteerService record, or null if not found.
+     */
     public function getVolunteerServiceForService(Service $service): ?VolunteerService
     {
         foreach ($this->volunteerServices as $vs) {

--- a/src/Entity/VolunteerService.php
+++ b/src/Entity/VolunteerService.php
@@ -8,44 +8,73 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\DBAL\Types\Types; // Necesario para Types::DATETIME_MUTABLE y Types::FLOAT, Types::TEXT
 
+/**
+ * Represents the association between a Volunteer and a Service they are participating in.
+ * This entity acts as a link table and holds the collection of clock-in/out records for that participation.
+ */
 #[ORM\Entity(repositoryClass: VolunteerServiceRepository::class)]
 class VolunteerService
 {
+    /**
+     * @var int|null The unique identifier for this association.
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
+    /**
+     * @var Volunteer|null The volunteer participating in the service.
+     */
     #[ORM\ManyToOne(inversedBy: 'volunteerServices')]
     #[ORM\JoinColumn(nullable: false)]
     private ?Volunteer $volunteer = null;
 
+    /**
+     * @var Service|null The service the volunteer is participating in.
+     */
     #[ORM\ManyToOne(inversedBy: 'volunteerServices')]
-    // Si respondiste 'yes' a la pregunta de nullable, aquí diría 'nullable: true'.
-    // Si quieres que no sea nulo, déjalo como 'nullable: false' o elimínalo (por defecto es false).
-    // Te recomiendo que sea 'nullable: false' para consistencia.
     #[ORM\JoinColumn(nullable: false)]
     private ?Service $service = null;
 
+    /**
+     * @var Collection<int, Fichaje> A collection of clock-in/out records for this specific volunteer-service participation.
+     */
     #[ORM\OneToMany(mappedBy: 'volunteerService', targetEntity: Fichaje::class, cascade: ['persist', 'remove'])]
     #[ORM\OrderBy(['startTime' => 'ASC'])]
     private Collection $fichajes;
 
+    /**
+     * Initializes the fichajes collection.
+     */
     public function __construct()
     {
         $this->fichajes = new ArrayCollection();
     }
 
+    /**
+     * Gets the unique identifier for this association.
+     * @return int|null
+     */
     public function getId(): ?int
     {
         return $this->id;
     }
 
+    /**
+     * Gets the associated volunteer.
+     * @return Volunteer|null
+     */
     public function getVolunteer(): ?Volunteer
     {
         return $this->volunteer;
     }
 
+    /**
+     * Sets the associated volunteer.
+     * @param Volunteer|null $volunteer The volunteer.
+     * @return static
+     */
     public function setVolunteer(?Volunteer $volunteer): static
     {
         $this->volunteer = $volunteer;
@@ -53,11 +82,20 @@ class VolunteerService
         return $this;
     }
 
+    /**
+     * Gets the associated service.
+     * @return Service|null
+     */
     public function getService(): ?Service
     {
         return $this->service;
     }
 
+    /**
+     * Sets the associated service.
+     * @param Service|null $service The service.
+     * @return static
+     */
     public function setService(?Service $service): static
     {
         $this->service = $service;
@@ -66,6 +104,7 @@ class VolunteerService
     }
 
     /**
+     * Gets the collection of clock-in/out records (fichajes).
      * @return Collection<int, Fichaje>
      */
     public function getFichajes(): Collection
@@ -73,6 +112,11 @@ class VolunteerService
         return $this->fichajes;
     }
 
+    /**
+     * Adds a clock-in/out record to this association.
+     * @param Fichaje $fichaje The fichaje to add.
+     * @return static
+     */
     public function addFichaje(Fichaje $fichaje): static
     {
         if (!$this->fichajes->contains($fichaje)) {
@@ -83,6 +127,11 @@ class VolunteerService
         return $this;
     }
 
+    /**
+     * Removes a clock-in/out record from this association.
+     * @param Fichaje $fichaje The fichaje to remove.
+     * @return static
+     */
     public function removeFichaje(Fichaje $fichaje): static
     {
         if ($this->fichajes->removeElement($fichaje)) {
@@ -95,6 +144,10 @@ class VolunteerService
         return $this;
     }
 
+    /**
+     * Finds and returns the currently open clock-in record (one without an end time).
+     * @return Fichaje|null The open fichaje, or null if none is open.
+     */
     public function getOpenFichaje(): ?Fichaje
     {
         foreach ($this->fichajes as $fichaje) {
@@ -106,6 +159,13 @@ class VolunteerService
         return null;
     }
 
+    /**
+     * Calculates the total duration of the volunteer's participation in minutes.
+     * It sums the duration of all associated clock-in/out records. For open records (without an end time),
+     * it uses the service's end time as the calculation basis.
+     *
+     * @return int The total duration in minutes.
+     */
     public function calculateTotalDuration(): int
     {
         if ($this->fichajes->isEmpty()) {

--- a/src/Form/FuelTypeType.php
+++ b/src/Form/FuelTypeType.php
@@ -8,8 +8,17 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * Form type for creating and editing FuelType entities.
+ */
 class FuelTypeType extends AbstractType
 {
+    /**
+     * Builds the form structure.
+     *
+     * @param FormBuilderInterface $builder The form builder.
+     * @param array $options The options for building the form.
+     */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -19,6 +28,11 @@ class FuelTypeType extends AbstractType
             ]);
     }
 
+    /**
+     * Configures the options for this form type.
+     *
+     * @param OptionsResolver $resolver The resolver for the options.
+     */
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([

--- a/src/Form/ServiceType.php
+++ b/src/Form/ServiceType.php
@@ -18,8 +18,22 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
+/**
+ * Form type for creating and editing Service entities.
+ * This form includes all fields necessary to define a service, from basic details to resource requirements.
+ */
 class ServiceType extends AbstractType
 {
+    /**
+     * Builds the form structure for the Service entity.
+     *
+     * This method defines all the fields for the form. It also includes a PRE_SUBMIT event listener
+     * to combine the 'numDues' and 'numTecnicos' fields into the 'numNurses' field before submission,
+     * as 'numDues' and 'numTecnicos' are for user interface purposes only and are not mapped to the entity.
+     *
+     * @param FormBuilderInterface $builder The form builder.
+     * @param array $options The options for building the form.
+     */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -181,6 +195,11 @@ class ServiceType extends AbstractType
         });
     }
 
+    /**
+     * Configures the options for this form type.
+     *
+     * @param OptionsResolver $resolver The resolver for the options.
+     */
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -11,8 +11,18 @@ use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Length;
 
+/**
+ * Form type for creating and editing User entities.
+ * This form is typically embedded within other forms, like VolunteerType.
+ */
 class UserType extends AbstractType
 {
+    /**
+     * Builds the form structure for the User entity.
+     *
+     * @param FormBuilderInterface $builder The form builder.
+     * @param array $options The options for building the form.
+     */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -27,8 +37,8 @@ class UserType extends AbstractType
             ])
             ->add('password', PasswordType::class, [
                 'label' => 'Contraseña',
-                'required' => !$options['is_edit'], // Solo requerido si no es edición
-                'mapped' => false, // No mapear directamente, se maneja en el controlador
+                'required' => !$options['is_edit'], // Only required when creating, not editing
+                'mapped' => false, // Not mapped directly, handled in the controller
                 'constraints' => $this->getPasswordConstraints($options['is_edit']),
                 'attr' => [
                     'placeholder' => $options['is_edit'] ? 'Dejar en blanco para no cambiar' : 'Introduce una contraseña',
@@ -36,11 +46,17 @@ class UserType extends AbstractType
             ]);
     }
 
+    /**
+     * Gets the appropriate validation constraints for the password field based on the context.
+     *
+     * @param bool $isEdit Whether the form is in edit mode.
+     * @return array An array of validation constraints.
+     */
     private function getPasswordConstraints(bool $isEdit): array
     {
-        // La restricción Length siempre se aplica si se introduce un valor.
-        // Si es edición y el campo está vacío, no se validará Length gracias a 'required' => false
-        // y la ausencia de NotBlank si $isEdit es true.
+        // The Length constraint always applies if a value is entered.
+        // If it's an edit form and the field is empty, Length won't be validated
+        // thanks to 'required' => false and the absence of NotBlank.
         $constraints = [
             new Length([
                 'min' => 6,
@@ -50,7 +66,7 @@ class UserType extends AbstractType
         ];
 
         if (!$isEdit) {
-            // Solo añadir NotBlank si estamos creando un nuevo usuario (no en edición)
+            // Only add NotBlank if we are creating a new user (not in edit mode)
             array_unshift($constraints, new NotBlank([
                 'message' => 'Por favor, introduce una contraseña.',
             ]));
@@ -59,6 +75,14 @@ class UserType extends AbstractType
         return $constraints;
     }
 
+    /**
+     * Configures the options for this form type.
+     *
+     * It defines a custom option `is_edit` to differentiate between creation and editing contexts,
+     * which controls whether the password field is required.
+     *
+     * @param OptionsResolver $resolver The resolver for the options.
+     */
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([

--- a/src/Form/VehicleType.php
+++ b/src/Form/VehicleType.php
@@ -13,8 +13,17 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\File;
 
+/**
+ * Form type for creating and editing Vehicle entities.
+ */
 class VehicleType extends AbstractType
 {
+    /**
+     * Builds the form structure for the Vehicle entity.
+     *
+     * @param FormBuilderInterface $builder The form builder.
+     * @param array $options The options for building the form.
+     */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -85,6 +94,11 @@ class VehicleType extends AbstractType
             ]);
     }
 
+    /**
+     * Configures the options for this form type.
+     *
+     * @param OptionsResolver $resolver The resolver for the options.
+     */
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([

--- a/src/Form/VolunteerType.php
+++ b/src/Form/VolunteerType.php
@@ -15,8 +15,22 @@ use App\Form\UserType;
 use Symfony\Component\Form\Extension\Core\Type\FileType; // ¡AÑADE ESTA LÍNEA!
 use Symfony\Component\Validator\Constraints\File; // ¡AÑADE ESTA LÍNEA!
 
+/**
+ * Form type for creating and editing Volunteer profiles.
+ * This is a comprehensive form that covers personal data, contact information, qualifications, and account details.
+ */
 class VolunteerType extends AbstractType
 {
+    /**
+     * Builds the form structure for the Volunteer entity.
+     *
+     * This method defines all the fields required for a volunteer's profile, organized into sections.
+     * It includes personal details, emergency contacts, professional information, qualifications, and embeds the UserType form
+     * for account management.
+     *
+     * @param FormBuilderInterface $builder The form builder.
+     * @param array $options The options for building the form, including a custom 'is_edit' option.
+     */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -272,6 +286,14 @@ class VolunteerType extends AbstractType
         ;
     }
 
+    /**
+     * Configures the options for this form type.
+     *
+     * It defines a custom option `is_edit` to differentiate between creation and editing contexts,
+     * which is passed down to the embedded UserType form.
+     *
+     * @param OptionsResolver $resolver The resolver for the options.
+     */
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -5,6 +5,12 @@ namespace App;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
+/**
+ * The application kernel.
+ *
+ * This class is the heart of the Symfony application. It's responsible for
+ * loading bundles, configuring the application, and handling requests.
+ */
 class Kernel extends BaseKernel
 {
     use MicroKernelTrait;

--- a/src/Repository/AssistanceConfirmationRepository.php
+++ b/src/Repository/AssistanceConfirmationRepository.php
@@ -8,15 +8,31 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
+ * Repository for AssistanceConfirmation entities.
+ *
  * @extends ServiceEntityRepository<AssistanceConfirmation>
+ *
+ * @method AssistanceConfirmation|null find($id, $lockMode = null, $lockVersion = null)
+ * @method AssistanceConfirmation|null findOneBy(array $criteria, array $orderBy = null)
+ * @method AssistanceConfirmation[]    findAll()
+ * @method AssistanceConfirmation[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
 class AssistanceConfirmationRepository extends ServiceEntityRepository
 {
+    /**
+     * @param ManagerRegistry $registry The manager registry.
+     */
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, AssistanceConfirmation::class);
     }
 
+    /**
+     * Counts the number of volunteers attending a specific service.
+     *
+     * @param Service $service The service to count attendees for.
+     * @return int The total number of attending volunteers.
+     */
     public function countAttendingByService(Service $service): int
     {
         return $this->count([

--- a/src/Repository/FichajeRepository.php
+++ b/src/Repository/FichajeRepository.php
@@ -8,6 +8,8 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
+ * Repository for Fichaje (clock-in/out) entities.
+ *
  * @extends ServiceEntityRepository<Fichaje>
  *
  * @method Fichaje|null find($id, $lockMode = null, $lockVersion = null)
@@ -17,11 +19,21 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class FichajeRepository extends ServiceEntityRepository
 {
+    /**
+     * @param ManagerRegistry $registry The manager registry.
+     */
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Fichaje::class);
     }
 
+    /**
+     * Finds a clock-in record that has not yet been closed (i.e., has no end time).
+     *
+     * @param VolunteerService $volunteerService The volunteer-service association to search within.
+     * @return Fichaje|null The open clock-in record, or null if none is found.
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
     public function findOpenFichaje(VolunteerService $volunteerService): ?Fichaje
     {
         return $this->createQueryBuilder('f')

--- a/src/Repository/FuelTypeRepository.php
+++ b/src/Repository/FuelTypeRepository.php
@@ -7,6 +7,8 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
+ * Repository for FuelType entities.
+ *
  * @extends ServiceEntityRepository<FuelType>
  *
  * @method FuelType|null find($id, $lockMode = null, $lockVersion = null)
@@ -16,6 +18,9 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class FuelTypeRepository extends ServiceEntityRepository
 {
+    /**
+     * @param ManagerRegistry $registry The manager registry.
+     */
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, FuelType::class);

--- a/src/Repository/ServiceRepository.php
+++ b/src/Repository/ServiceRepository.php
@@ -7,17 +7,28 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
+ * Repository for Service entities.
+ *
  * @extends ServiceEntityRepository<Service>
+ *
+ * @method Service|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Service|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Service[]    findAll()
+ * @method Service[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
 class ServiceRepository extends ServiceEntityRepository
 {
+    /**
+     * @param ManagerRegistry $registry The manager registry.
+     */
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Service::class);
     }
 
     /**
-     * Obtiene todos los servicios activos (ejemplo si tuvieras un campo booleano llamado isActive)
+     * Finds all services that are currently active (i.e., the current date is between the start and end dates).
+     * @return Service[] Returns an array of active Service objects.
      */
     public function findActive(): array
     {
@@ -31,7 +42,9 @@ class ServiceRepository extends ServiceEntityRepository
     }
 
     /**
-     * Obtiene los servicios por categoría
+     * Finds all services belonging to a specific category.
+     * @param string $category The category to search for.
+     * @return Service[] Returns an array of Service objects.
      */
     public function findByCategory(string $category): array
     {
@@ -44,7 +57,9 @@ class ServiceRepository extends ServiceEntityRepository
     }
 
     /**
-     * Busca servicios que coincidan con parte del título
+     * Finds services by performing a LIKE search on their title.
+     * @param string $query The search query.
+     * @return Service[] Returns an array of matching Service objects.
      */
     public function searchByTitle(string $query): array
     {
@@ -56,6 +71,11 @@ class ServiceRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * Finds all services that a specific volunteer has attended.
+     * @param mixed $volunteer The volunteer entity.
+     * @return Service[] Returns an array of Service objects.
+     */
     public function findServicesByVolunteer($volunteer): array
     {
         return $this->createQueryBuilder('s')
@@ -69,6 +89,11 @@ class ServiceRepository extends ServiceEntityRepository
         ;
     }
 
+    /**
+     * Finds all services scheduled to start on a specific date.
+     * @param \DateTimeInterface $date The date to search for.
+     * @return Service[] Returns an array of Service objects.
+     */
     public function findByDate(\DateTimeInterface $date): array
     {
         $startOfDay = (clone $date)->setTime(0, 0, 0);
@@ -84,6 +109,12 @@ class ServiceRepository extends ServiceEntityRepository
         ;
     }
 
+    /**
+     * Counts the number of services that started in the current month.
+     * @return int The total count of services.
+     * @throws \Doctrine\ORM\NoResultException
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
     public function countServicesThisMonth(): int
     {
         $startDate = new \DateTime('first day of this month 00:00:00');
@@ -98,6 +129,12 @@ class ServiceRepository extends ServiceEntityRepository
             ->getSingleScalarResult();
     }
 
+    /**
+     * Counts the number of services that have already been completed (end date is in the past).
+     * @return int The total count of completed services.
+     * @throws \Doctrine\ORM\NoResultException
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
     public function countCompletedServices(): int
     {
         return (int) $this->createQueryBuilder('s')
@@ -108,6 +145,10 @@ class ServiceRepository extends ServiceEntityRepository
             ->getSingleScalarResult();
     }
 
+    /**
+     * Finds all services that were completed within the current year.
+     * @return Service[] Returns an array of completed Service objects for the current year.
+     */
     public function findCompletedServicesThisYear(): array
     {
         $startDate = new \DateTime('first day of january this year 00:00:00');

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -9,13 +9,32 @@ use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 
+/**
+ * Repository for User entities.
+ *
+ * @extends ServiceEntityRepository<User>
+ *
+ * @method User|null find($id, $lockMode = null, $lockVersion = null)
+ * @method User|null findOneBy(array $criteria, array $orderBy = null)
+ * @method User[]    findAll()
+ * @method User[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
 class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface
 {
+    /**
+     * @param ManagerRegistry $registry The manager registry.
+     */
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, User::class);
     }
 
+    /**
+     * Used to upgrade (rehash) the user's password automatically over time.
+     *
+     * @param PasswordAuthenticatedUserInterface $user The user to upgrade.
+     * @param string $newHashedPassword The new hashed password.
+     */
     public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void
     {
         if (!$user instanceof User) {

--- a/src/Repository/VehicleRepository.php
+++ b/src/Repository/VehicleRepository.php
@@ -7,6 +7,8 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
+ * Repository for Vehicle entities.
+ *
  * @extends ServiceEntityRepository<Vehicle>
  *
  * @method Vehicle|null find($id, $lockMode = null, $lockVersion = null)
@@ -16,11 +18,21 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class VehicleRepository extends ServiceEntityRepository
 {
+    /**
+     * @param ManagerRegistry $registry The manager registry.
+     */
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Vehicle::class);
     }
 
+    /**
+     * Counts the number of vehicles that are currently available (not out of service).
+     *
+     * @return int The total count of available vehicles.
+     * @throws \Doctrine\ORM\NoResultException
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
     public function countAvailableVehicles(): int
     {
         return $this->count(['isOutOfService' => false]);

--- a/src/Repository/VolunteerRepository.php
+++ b/src/Repository/VolunteerRepository.php
@@ -6,13 +6,31 @@ use App\Entity\Volunteer;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
+/**
+ * Repository for Volunteer entities.
+ *
+ * @extends ServiceEntityRepository<Volunteer>
+ *
+ * @method Volunteer|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Volunteer|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Volunteer[]    findAll()
+ * @method Volunteer[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
 class VolunteerRepository extends ServiceEntityRepository
 {
+    /**
+     * @param ManagerRegistry $registry The manager registry.
+     */
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Volunteer::class);
     }
 
+    /**
+     * Finds volunteers by a search term matching their name or email.
+     * @param string $searchTerm The term to search for.
+     * @return Volunteer[] Returns an array of matching Volunteer objects.
+     */
     public function findBySearchTerm(string $searchTerm): array
     {
         return $this->createQueryBuilder('v')
@@ -23,6 +41,11 @@ class VolunteerRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * Finds volunteers by their status.
+     * @param string $status The status to filter by.
+     * @return Volunteer[] Returns an array of matching Volunteer objects.
+     */
     public function findByStatus(string $status): array
     {
         return $this->createQueryBuilder('v')
@@ -33,6 +56,12 @@ class VolunteerRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * Counts the number of volunteers with a 'pending' status.
+     * @return int The total count of pending volunteers.
+     * @throws \Doctrine\ORM\NoResultException
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
     public function countPendingVolunteers(): int
     {
         return (int) $this->createQueryBuilder('v')
@@ -43,11 +72,23 @@ class VolunteerRepository extends ServiceEntityRepository
             ->getSingleScalarResult();
     }
 
+    /**
+     * Counts the number of volunteers with an 'active' status.
+     * @return int The total count of active volunteers.
+     * @throws \Doctrine\ORM\NoResultException
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
     public function countActiveVolunteers(): int
     {
         return $this->count(['status' => Volunteer::STATUS_ACTIVE]);
     }
 
+    /**
+     * Counts the number of new volunteers who joined in the current month.
+     * @return int The total count of new volunteers this month.
+     * @throws \Doctrine\ORM\NoResultException
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
     public function countNewVolunteersThisMonth(): int
     {
         $startDate = new \DateTime('first day of this month 00:00:00');

--- a/src/Repository/VolunteerServiceRepository.php
+++ b/src/Repository/VolunteerServiceRepository.php
@@ -7,17 +7,30 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
+ * Repository for VolunteerService entities.
+ *
  * @extends ServiceEntityRepository<VolunteerService>
+ *
+ * @method VolunteerService|null find($id, $lockMode = null, $lockVersion = null)
+ * @method VolunteerService|null findOneBy(array $criteria, array $orderBy = null)
+ * @method VolunteerService[]    findAll()
+ * @method VolunteerService[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
 class VolunteerServiceRepository extends ServiceEntityRepository
 {
+    /**
+     * @param ManagerRegistry $registry The manager registry.
+     */
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, VolunteerService::class);
     }
 
     /**
-     * @return VolunteerService[]
+     * Finds all service participations for a given volunteer, ordered by the service start date in descending order.
+     *
+     * @param \App\Entity\Volunteer $volunteer The volunteer to find services for.
+     * @return VolunteerService[] Returns an array of VolunteerService objects.
      */
     public function findForVolunteerOrderedByServiceDate(\App\Entity\Volunteer $volunteer): array
     {
@@ -47,7 +60,11 @@ class VolunteerServiceRepository extends ServiceEntityRepository
     //    }
 
     /**
-     * @return VolunteerService[]
+     * Finds all service participations for a given service, eagerly loading the associated clock-in/out records
+     * and ordering them by start time in descending order.
+     *
+     * @param \App\Entity\Service $service The service to find participations for.
+     * @return VolunteerService[] Returns an array of VolunteerService objects with their fichajes.
      */
     public function findByServiceWithOrderedFichajes(\App\Entity\Service $service): array
     {

--- a/src/Security/Voter/FichajeVoter.php
+++ b/src/Security/Voter/FichajeVoter.php
@@ -9,27 +9,48 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
 
+/**
+ * A Symfony Voter to determine if a user has permission to manage clock-in/out records (fichajes) for a given service.
+ */
 class FichajeVoter extends Voter
 {
+    /** @var string The permission to manage fichajes. */
     public const MANAGE_FICHANJE = 'MANAGE_FICHANJE';
 
     private Security $security;
 
+    /**
+     * FichajeVoter constructor.
+     * @param Security $security The security component to check for roles.
+     */
     public function __construct(Security $security)
     {
         $this->security = $security;
     }
 
+    /**
+     * Determines if this voter supports the given attribute and subject.
+     *
+     * @param string $attribute The attribute to check (e.g., 'MANAGE_FICHANJE').
+     * @param mixed $subject The subject to check (must be an instance of Service).
+     * @return bool True if this voter supports the attribute and subject, false otherwise.
+     */
     protected function supports(string $attribute, $subject): bool
     {
         return $attribute === self::MANAGE_FICHANJE && $subject instanceof Service;
     }
 
     /**
-     * @param string $attribute
-     * @param Service $subject
-     * @param TokenInterface $token
-     * @return bool
+     * Performs the main authorization logic.
+     *
+     * A user can manage fichajes if:
+     * - They have the ROLE_ADMIN or ROLE_COORDINATOR.
+     * - They are a volunteer who has been designated as the responsible person for fichajes for that specific service.
+     *
+     * @param string $attribute The attribute being voted on.
+     * @param Service $subject The service entity.
+     * @param TokenInterface $token The user's security token.
+     * @return bool True to grant access, false otherwise.
      */
     protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
     {

--- a/src/Service/WhatsAppMessageGenerator.php
+++ b/src/Service/WhatsAppMessageGenerator.php
@@ -6,17 +6,35 @@ use App\Entity\Service;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+/**
+ * A service responsible for generating formatted WhatsApp messages for service announcements.
+ */
 class WhatsAppMessageGenerator
 {
     private TranslatorInterface $translator;
     private UrlGeneratorInterface $urlGenerator;
 
+    /**
+     * WhatsAppMessageGenerator constructor.
+     *
+     * @param TranslatorInterface $translator The translator service for internationalization.
+     * @param UrlGeneratorInterface $urlGenerator The URL generator service to create absolute URLs.
+     */
     public function __construct(TranslatorInterface $translator, UrlGeneratorInterface $urlGenerator)
     {
         $this->translator = $translator;
         $this->urlGenerator = $urlGenerator;
     }
 
+    /**
+     * Creates a formatted, multi-line string suitable for a WhatsApp message from a Service entity.
+     *
+     * The message includes the service title, date, timings, location, required resources, tasks,
+     * and direct links for volunteers to confirm or decline attendance.
+     *
+     * @param Service $service The service entity to generate the message for.
+     * @return string The formatted WhatsApp message.
+     */
     public function createMessage(Service $service): string
     {
         $message = [];

--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -7,15 +7,28 @@ use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\TwigFilter;
 
+/**
+ * Custom Twig extension to provide global variables and custom filters to the templates.
+ */
 class AppExtension extends AbstractExtension implements GlobalsInterface
 {
     private $volunteerRepository;
 
+    /**
+     * AppExtension constructor.
+     *
+     * @param VolunteerRepository $volunteerRepository The repository for volunteers, used to fetch global data.
+     */
     public function __construct(VolunteerRepository $volunteerRepository)
     {
         $this->volunteerRepository = $volunteerRepository;
     }
 
+    /**
+     * Defines global variables available in all Twig templates.
+     *
+     * @return array An array of global variables.
+     */
     public function getGlobals(): array
     {
         return [
@@ -23,6 +36,11 @@ class AppExtension extends AbstractExtension implements GlobalsInterface
         ];
     }
 
+    /**
+     * Defines custom filters available in Twig templates.
+     *
+     * @return TwigFilter[] An array of Twig filters.
+     */
     public function getFilters(): array
     {
         return [
@@ -30,6 +48,13 @@ class AppExtension extends AbstractExtension implements GlobalsInterface
         ];
     }
 
+    /**
+     * Formats a DateTime object into a Spanish-style short date string.
+     * Example: "Lun, 01 de Ene de 24"
+     *
+     * @param \DateTimeInterface $date The date to format.
+     * @return string The formatted date string.
+     */
     public function formatSpanishDate(\DateTimeInterface $date): string
     {
         $days = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\User;
+use App\Entity\Volunteer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the User entity.
+ * @group Entity
+ */
+class UserTest extends TestCase
+{
+    /**
+     * Tests that a new User object can be instantiated and its default values are correct.
+     */
+    public function testNewUser(): void
+    {
+        $user = new User();
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertNull($user->getId());
+        $this->assertNull($user->getEmail());
+        $this->assertContains('ROLE_USER', $user->getRoles());
+        $this->assertNull($user->getVolunteer());
+    }
+
+    /**
+     * Tests the getter and setter for the email property.
+     */
+    public function testGetSetEmail(): void
+    {
+        $user = new User();
+        $email = 'test@example.com';
+        $user->setEmail($email);
+
+        $this->assertSame($email, $user->getEmail());
+        $this->assertSame($email, $user->getUserIdentifier());
+    }
+
+    /**
+     * Tests the role management logic.
+     */
+    public function testRoles(): void
+    {
+        $user = new User();
+        $this->assertEquals(['ROLE_USER'], $user->getRoles());
+
+        $user->setRoles(['ROLE_ADMIN']);
+        // ROLE_USER should always be present
+        $this->assertContains('ROLE_USER', $user->getRoles());
+        $this->assertContains('ROLE_ADMIN', $user->getRoles());
+
+        // Test that roles are unique
+        $user->setRoles(['ROLE_VOLUNTEER', 'ROLE_VOLUNTEER']);
+        $this->assertCount(2, $user->getRoles()); // ROLE_VOLUNTEER and ROLE_USER
+    }
+
+    /**
+     * Tests the getter and setter for the password property.
+     */
+    public function testGetSetPassword(): void
+    {
+        $user = new User();
+        $password = 'a_very_secure_password';
+        $user->setPassword($password);
+
+        $this->assertSame($password, $user->getPassword());
+    }
+
+    /**
+     * Tests the bidirectional relationship between User and Volunteer.
+     */
+    public function testGetSetVolunteer(): void
+    {
+        $user = new User();
+        $volunteer = new Volunteer();
+
+        $user->setVolunteer($volunteer);
+
+        $this->assertSame($volunteer, $user->getVolunteer());
+        // Check if the back-reference was set correctly
+        $this->assertSame($user, $volunteer->getUser());
+    }
+
+    /**
+     * Tests that setting the same volunteer again does not cause issues.
+     */
+    public function testSetSameVolunteer(): void
+    {
+        $user = new User();
+        $volunteer = new Volunteer();
+
+        $user->setVolunteer($volunteer);
+        $user->setVolunteer($volunteer); // Set the same volunteer again
+
+        $this->assertSame($volunteer, $user->getVolunteer());
+        $this->assertSame($user, $volunteer->getUser());
+    }
+
+    /**
+     * Tests that eraseCredentials does not throw an error.
+     */
+    public function testEraseCredentials(): void
+    {
+        $user = new User();
+        $user->setEmail('test@example.com');
+        $user->setPassword('password');
+
+        // The method is expected to be empty, so we just check it doesn't throw an error.
+        $user->eraseCredentials();
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
This commit introduces thorough documentation across the entire repository to improve maintainability and onboarding for new developers.

- Adds PHPDoc-style docstrings to all public classes, methods, and properties in the `src/` directory, including controllers, entities, forms, repositories, services, and security voters.
- Completely rewrites the `README.md` file to serve as a comprehensive guide, including a project overview, tech stack, detailed setup instructions, and a project structure summary.
- Adds a basic unit test for the User entity to establish a testing foundation.