### PR TITLE
feat: Implement volunteer modal and enhanced activity feed

### DIFF
--- a/src/Controller/InvitationController.php
+++ b/src/Controller/InvitationController.php
@@ -28,8 +28,8 @@ class InvitationController extends AbstractController
             ->html($this->renderView('emails/invitation.html.twig'));
 
         try {
-            $mailer->send($email);
-            return new JsonResponse(['message' => 'Invitation sent successfully!']);
+            // $mailer->send($email); // Descomentar cuando el problema de conexión con Mailtrap esté resuelto.
+            return new JsonResponse(['message' => 'Invitation sent successfully! (Email sending is disabled for now)']);
         } catch (\Exception $e) {
             return new JsonResponse(['error' => 'Could not send email.'], 500);
         }


### PR DESCRIPTION
This commit delivers two major features requested by the user.

First, it enhances the 'Recent Activity' feed on the admin dashboard.
- A `statusChangeDate` field has been added to the `Volunteer` entity to track status updates.
- The dashboard now correctly fetches and displays all volunteer status changes (new, suspended, inactive) and completed services from the last 30 days.

Second, it implements a new modal for adding volunteers.
- The 'Añadir Voluntario' button now opens a modal with two options: 'Añadir manualmente' and 'Enviar inscripción'.
- The 'Enviar inscripción' option allows an admin to send an invitation email to a specified address.
- A new `InvitationController` and email template have been created to support this functionality.
- The link in the invitation email now correctly points to the login page to avoid routing errors.
- The mailer `send` call has been temporarily commented out to prevent errors in local environments with network restrictions.