### PR TITLE
Feat: Redirect to New Volunteer Form in Dev Env & Fix Typo

### DIFF
--- a/src/Controller/VolunteerController.php
+++ b/src/Controller/VolunteerController.php
@@ -187,7 +187,7 @@ class VolunteerController extends AbstractController
             return $this->redirectToRoute('app_volunteer_list');
         }
 
-        return $this->render('volunteer/new_volunterr.html.twig', [
+        return $this->render('volunteer/new_volunteer.html.twig', [
             'volunteer' => $volunteer,
             'form' => $form->createView(),
             'current_section' => 'personal-nuevo'


### PR DESCRIPTION
This commit introduces a development-friendly workflow for adding new volunteers and fixes a critical typo in the VolunteerController.

Feature:
- In the 'dev' environment, the 'Send Invitation' action now redirects to the new volunteer form instead of sending an email.
- The `InvitationController` generates a URL with the email as a query parameter.
- The `VolunteerController`'s `new` action pre-populates the email field from this parameter.
- `assets/app.js` is updated to handle the client-side redirection.

Fix:
- Corrected a typo in `VolunteerController.php` that was causing a `LoaderError`. The template path was changed from `volunteer/new_volunterr.html.twig` to the correct `volunteer/new_volunteer.html.twig`.