### PR TITLE
feat: Configure mailer 'From' address via environment variable

### DIFF
--- a/config/packages/mailer.yaml
+++ b/config/packages/mailer.yaml
@@ -1,3 +1,5 @@
 framework:
     mailer:
         dsn: '%env(MAILER_DSN)%'
+        envelope:
+            sender: '%env(MAILER_FROM_ADDRESS)%'

--- a/src/Controller/InvitationController.php
+++ b/src/Controller/InvitationController.php
@@ -45,7 +45,6 @@ class InvitationController extends AbstractController
         ]);
 
         $email = (new Email())
-            ->from('no-reply@proteccioncivilvigo.org')
             ->to($recipientEmail)
             ->subject('Invitación para unirte a Protección Civil de Vigo')
             ->html($emailBody);


### PR DESCRIPTION
The 'From' email address was previously hardcoded in the InvitationController, causing issues with email delivery.

This change moves the 'From' address to a `MAILER_FROM_ADDRESS` environment variable, configured in `config/packages/mailer.yaml`. A `.env` file has been created with a default value for this variable, allowing for easy configuration across different environments. The InvitationController now relies on the globally configured sender address.