### PR TITLE
feat: Unify public layout and registration forms

### DIFF
--- a/templates/error/unauthorized_invitation.html.twig
+++ b/templates/error/unauthorized_invitation.html.twig
@@ -1,15 +1,22 @@
-{% extends 'layout/app.html.twig' %}
+{% extends 'layout/public.html.twig' %}
 
 {% block title %}Invitación no válida{% endblock %}
-{% block page_title %}Acceso denegado{% endblock %}
 
 {% block content %}
-<div class="flex items-center justify-center min-h-[calc(100vh-200px)]">
+<div class="flex items-center justify-center min-h-screen">
     <div class="text-center p-8 bg-white rounded-xl shadow-md border border-gray-200 max-w-lg">
         <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100">
             <i data-lucide="x-circle" class="h-6 w-6 text-red-600"></i>
         </div>
         <h2 class="mt-4 text-2xl font-bold text-gray-900">Invitación no válida</h2>
+        <p class="mt-2 text-gray-600">
+            El enlace de invitación que has utilizado no es válido o ya ha sido utilizado. Por favor, contacta con un administrador para solicitar una nueva invitación.
+        </p>
+        <div class="mt-6">
+            <a href="{{ path('app_login') }}" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                Volver a la página de inicio
+            </a>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/templates/layout/public.html.twig
+++ b/templates/layout/public.html.twig
@@ -1,0 +1,31 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+<div class="flex h-screen bg-gray-50 justify-center">
+    <!-- Main content -->
+    <div class="flex-1 flex flex-col overflow-hidden max-w-4xl w-full">
+        <!-- Main content area -->
+        <main class="flex-1 overflow-y-auto p-6">
+            {% for message in app.flashes('success') %}
+                <div class="mb-4 p-4 bg-green-50 border border-green-200 rounded-lg">
+                    <div class="flex items-center">
+                        <i data-lucide="check-circle" class="w-5 h-5 text-green-500 mr-2"></i>
+                        <span class="text-green-800">{{ message }}</span>
+                    </div>
+                </div>
+            {% endfor %}
+
+            {% for message in app.flashes('error') %}
+                <div class="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg">
+                    <div class="flex items-center">
+                        <i data-lucide="alert-circle" class="w-5 h-5 text-red-500 mr-2"></i>
+                        <span class="text-red-800">{{ message }}</span>
+                    </div>
+                </div>
+            {% endfor %}
+
+            {% block content %}{% endblock %}
+        </main>
+    </div>
+</div>
+{% endblock %}

--- a/templates/volunteer/new_volunteer.html.twig
+++ b/templates/volunteer/new_volunteer.html.twig
@@ -1,64 +1,145 @@
 {% extends 'layout/app.html.twig' %}
 
-{% block page_title %}Nuevo Voluntario{% endblock %}
+{% block page_title %}Crear Nuevo Voluntario{% endblock %}
 
 {% block content %}
-<div class="p-6">
-    <div class="max-w-2xl mx-auto">
-        <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-            <div class="mb-6">
-                <h2 class="text-xl font-semibold text-gray-900">Nuevo Voluntario</h2>
-                <p class="text-gray-600 mt-1">Completa la información del nuevo voluntario</p>
+<div class="container mx-auto p-6">
+    <h1 class="text-2xl font-bold mb-6 text-gray-900">
+        Crear Nuevo Voluntario
+    </h1>
+
+    {{ form_start(form, {'attr': {'class': 'bg-white p-6 rounded-lg shadow-md'}, 'enctype': 'multipart/form-data'}) }}
+
+    <div class="flex flex-col md:flex-row gap-6 mb-8">
+        <div class="w-full md:w-1/2 p-4 border border-gray-200 rounded-lg text-center bg-gray-50">
+            <h3 class="text-xl font-semibold mb-4 text-gray-800">Foto de Perfil</h3>
+            <div class="mb-4">
+                <div id="preview-element" class="w-32 h-32 rounded-full mx-auto bg-gray-300 flex items-center justify-center text-gray-600 text-sm mb-4 border-2 border-blue-300 shadow">
+                    Sin Foto
+                </div>
             </div>
+            <div class="w-fit mx-auto">
+                {{ form_row(form.profilePicture, {
+                    label: 'Subir foto',
+                    attr: {
+                        'class': 'block text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none'
+                    }
+                }) }}
+            </div>
+            <p class="text-xs text-gray-500 mt-1">Sube una imagen JPG o PNG (máx. 1MB).</p>
+        </div>
 
-            {{ form_start(form, {'attr': {'class': 'space-y-6'}}) }}
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div>
-                        {{ form_label(form.name, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2'}}) }}
-                        {{ form_widget(form.name) }}
-                        {{ form_errors(form.name) }}
-                    </div>
-
-                    <div>
-                        {{ form_label(form.user.email, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2'}}) }}
-                        {{ form_widget(form.user.email) }}
-                        {{ form_errors(form.user.email) }}
-                    </div>
-
-                   
-
-                    <div>
-                        {{ form_label(form.phone, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2'}}) }}
-                        {{ form_widget(form.phone) }}
-                        {{ form_errors(form.phone) }}
-                    </div>
-
-                    <div>
-                        {{ form_label(form.role, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2'}}) }}
-                        {{ form_widget(form.role) }}
-                        {{ form_errors(form.role) }}
-                    </div>
-
-                    <div>
-                        {{ form_label(form.specialization, null, {'label_attr': {'class': 'block text-sm font-medium text-gray-700 mb-2'}}) }}
-                        {{ form_widget(form.specialization) }}
-                        {{ form_errors(form.specialization) }}
-                    </div>
-
+        <div class="w-full md:w-1/2 p-4 border border-gray-200 rounded-lg bg-gray-50">
+            <h3 class="text-xl font-semibold mb-4 text-gray-800">Datos Básicos</h3>
+            <div class="grid grid-cols-2 gap-x-6">
+                <div class="col-span-1">
+                    {{ form_row(form.name) }}
                 </div>
-
-                <div class="flex gap-3 pt-6">
-                    <a href="{{ path('app_volunteer_list') }}" 
-                       class="flex-1 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors text-center">
-                        Cancelar
-                    </a>
-                    <button type="submit" 
-                            class="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
-                        Guardar Voluntario
-                    </button>
+                <div class="col-span-1">
+                    {{ form_row(form.lastName) }}
                 </div>
-            {{ form_end(form) }}
+                <div class="col-span-1 mt-4">
+                    {{ form_row(form.phone) }}
+                </div>
+                <div class="col-span-1 mt-4">
+                    {{ form_row(form.user.email) }}
+                </div>
+                <div class="col-span-1 mt-4">
+                    {{ form_row(form.dni) }}
+                </div>
+                <div class="col-span-1 mt-4">
+                    {{ form_row(form.dateOfBirth) }}
+                </div>
+            </div>
         </div>
     </div>
+
+    <div class="w-full p-4 border border-gray-200 rounded-lg bg-white mb-8">
+        <h3 class="text-xl font-semibold mb-4 text-gray-800">Datos Detallados del Voluntario</h3>
+
+        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Dirección</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>{{ form_row(form.streetType) }}</div>
+            <div>{{ form_row(form.address) }}</div>
+            <div>{{ form_row(form.postalCode) }}</div>
+            <div>{{ form_row(form.province) }}</div>
+            <div>{{ form_row(form.city) }}</div>
+        </div>
+
+        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Información de Emergencia</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>{{ form_row(form.contactPerson1) }}</div>
+            <div>{{ form_row(form.contactPhone1) }}</div>
+            <div>{{ form_row(form.contactPerson2) }}</div>
+            <div>{{ form_row(form.contactPhone2) }}</div>
+        </div>
+
+        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Información Médica</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>{{ form_row(form.allergies) }}</div>
+        </div>
+
+        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Profesional y Cualificaciones</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>{{ form_row(form.profession) }}</div>
+            <div>{{ form_row(form.employmentStatus) }}</div>
+            <div>{{ form_row(form.drivingLicenses) }}</div>
+            <div>{{ form_row(form.drivingLicenseExpiryDate) }}</div>
+        </div>
+        <div class="mb-4">{{ form_row(form.navigationLicenses) }}</div>
+        <div class="mb-4">{{ form_row(form.specificQualifications) }}</div>
+        <div class="mb-4">{{ form_row(form.otherQualifications) }}</div>
+
+        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Otros Datos e Intereses</h2>
+        <div class="mb-4">{{ form_row(form.languages) }}</div>
+        <div class="mb-4">{{ form_row(form.motivation) }}</div>
+        <div class="mb-4">{{ form_row(form.howKnown) }}</div>
+        <div class="mb-4">{{ form_row(form.hasVolunteeredBefore) }}</div>
+        <div class="mb-4">{{ form_row(form.previousVolunteeringInstitutions) }}</div>
+
+        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Rol y Especialización</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>{{ form_row(form.role) }}</div>
+            <div>{{ form_row(form.specialization) }}</div>
+        </div>
+
+        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Contraseña</h2>
+        <div class="mb-4">{{ form_row(form.user.password) }}</div>
+    </div>
+
+    <div class="flex items-center justify-end gap-3 mt-6">
+        <a href="{{ path('app_volunteer_list') }}" class="px-4 py-2 bg-gray-300 text-gray-800 rounded-lg hover:bg-gray-400 transition-colors">Cancelar</a>
+        <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors">Crear Voluntario</button>
+    </div>
+
+    {{ form_end(form) }}
 </div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const profilePictureInput = document.querySelector('input[type="file"][name$="[profilePicture]"]');
+        let previewElement = document.getElementById('preview-element');
+
+        if (profilePictureInput && previewElement) {
+            profilePictureInput.addEventListener('change', function (event) {
+                const file = event.target.files[0];
+                if (file) {
+                    const reader = new FileReader();
+                    reader.onload = function (e) {
+                        if (previewElement.tagName === 'DIV') {
+                            const newImg = document.createElement('img');
+                            newImg.id = 'preview-element';
+                            newImg.alt = 'Foto de perfil';
+                            newImg.className = 'w-32 h-32 rounded-full object-cover mx-auto border-2 border-blue-300 shadow mb-4';
+                            previewElement.parentNode.replaceChild(newImg, previewElement);
+                            previewElement = newImg;
+                        }
+                        previewElement.src = e.target.result;
+                    };
+                    reader.readAsDataURL(file);
+                }
+            });
+        }
+    });
+</script>
 {% endblock %}

--- a/templates/volunteer/registration_form.html.twig
+++ b/templates/volunteer/registration_form.html.twig
@@ -1,125 +1,141 @@
-{# templates/volunteer/registration_form.html.twig #}
+{% extends 'layout/public.html.twig' %}
 
-{% extends 'base.html.twig' %}
+{% block title %}Formulario de Inscripción{% endblock %}
 
-{% block title %}Inscripción de Voluntarios{% endblock %}
-
-{% block body %}
-    <div class="container mx-auto p-4">
-        <h1 class="text-2xl font-bold mb-6">Formulario de Inscripción de Voluntarios</h1>
-
-        {# Mostrar mensajes flash #}
-        {% for message in app.flashes('success') %}
-            <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-                <span class="block sm:inline">{{ message }}</span>
-            </div>
-        {% endfor %}
-        {% for message in app.flashes('error') %}
-            <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-                <span class="block sm:inline">{{ message }}</span>
-            </div>
-        {% endfor %}
-
-        {{ form_start(form, {'attr': {'class': 'bg-white p-6 rounded-lg shadow-md'}}) }}
-
-            {# Sección: Datos Personales #}
-            <h2 class="text-xl font-semibold mt-6 mb-4">--- Datos Personales ---</h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>{{ form_row(form.name) }}</div>
-                <div>{{ form_row(form.lastName) }}</div>
-                <div>{{ form_row(form.dni) }}</div>
-                <div>{{ form_row(form.dateOfBirth) }}</div>
-                <div>{{ form_row(form.streetType) }}</div>
-                <div>{{ form_row(form.address) }}</div>
-                <div>{{ form_row(form.postalCode) }}</div>
-                <div>{{ form_row(form.province) }}</div>
-                <div>{{ form_row(form.city) }}</div>
-                <div>{{ form_row(form.phone) }}</div>
-            </div>
-
-            {# Sección: Datos de Contacto de Emergencia #}
-            <h2 class="text-xl font-semibold mt-6 mb-4">--- Datos de Contacto de Emergencia ---</h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>{{ form_row(form.contactPerson1) }}</div>
-                <div>{{ form_row(form.contactPhone1) }}</div>
-                <div>{{ form_row(form.contactPerson2) }}</div>
-                <div>{{ form_row(form.contactPhone2) }}</div>
-            </div>
-
-            {# Sección: Datos de Salud #}
-            <h2 class="text-xl font-semibold mt-6 mb-4">--- Datos de Salud ---</h2>
-            <div class="mb-4">
-                {{ form_row(form.allergies) }}
-            </div>
-
-            {# Sección: Datos Profesionales #}
-            <h2 class="text-xl font-semibold mt-6 mb-4">--- Datos Profesionales ---</h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>{{ form_row(form.profession) }}</div>
-                <div>{{ form_row(form.employmentStatus) }}</div>
-            </div>
-            <div class="mb-4">
-                <label class="block text-gray-700 text-sm font-bold mb-2">Permiso de Conducción</label>
-                {{ form_widget(form.drivingLicenses) }} {# Muestra los checkboxes #}
-                {{ form_errors(form.drivingLicenses) }}
-            </div>
-            <div class="mb-4">
-                {{ form_row(form.drivingLicenseExpiryDate) }}
-            </div>
-
-            {# Sección: Otros Datos e Intereses #}
-            <h2 class="text-xl font-semibold mt-6 mb-4">--- Otros Datos e Intereses ---</h2>
-            <div class="mb-4">
-                {{ form_row(form.languages) }}
-            </div>
-            <div class="mb-4">
-                {{ form_row(form.motivation) }}
-            </div>
-            <div class="mb-4">
-                {{ form_row(form.howKnown) }}
-            </div>
-            <div class="mb-4">
-                <label class="block text-gray-700 text-sm font-bold mb-2">¿Ha realizado funciones de voluntariado con anterioridad?</label>
-                {{ form_widget(form.hasVolunteeredBefore) }}
-                {{ form_errors(form.hasVolunteeredBefore) }}
-            </div>
-            <div class="mb-4">
-                {{ form_row(form.previousVolunteeringInstitutions) }}
-            </div>
-            <div class="mb-4">
-                {{ form_row(form.otherQualifications) }}
-            </div>
-            <div class="mb-4">
-                <label class="block text-gray-700 text-sm font-bold mb-2">Permisos de Navegación</label>
-                {{ form_widget(form.navigationLicenses) }}
-                {{ form_errors(form.navigationLicenses) }}
-            </div>
-
-            {# Sección: Titulaciones Específicas (AHORA AGRUPADAS) #}
-            <h2 class="text-xl font-semibold mt-6 mb-4">--- Titulaciones Específicas ---</h2>
-            <div class="mb-4">
-                {# Renderiza el nuevo campo de titulaciones específicas como checkboxes #}
-                {{ form_row(form.specificQualifications) }}
-            </div>
-
-            {# Sección: Rol y Especialización #}
-            <h2 class="text-xl font-semibold mt-6 mb-4">--- Rol y Especialización ---</h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>{{ form_row(form.role) }}</div>
-                <div>{{ form_row(form.specialization) }}</div>
-            </div>
-
-            {# Sección: Datos de Acceso #}
-            <h2 class="text-xl font-semibold mt-6 mb-4">--- Datos de Acceso ---</h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>{{ form_row(form.user.email) }}</div>
-                <div>{{ form_row(form.user.password) }}</div>
-            </div>
-
-            <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline mt-6">
-                Enviar Solicitud
-            </button>
-
-        {{ form_end(form) }}
+{% block content %}
+<div class="container mx-auto p-6">
+    <div class="text-center mb-8">
+        <img src="https://www.proteccioncivilvigo.org/images/logo_color.png" alt="Logo Protección Civil Vigo" class="w-32 mx-auto mb-4">
+        <h1 class="text-3xl font-bold text-gray-900">Formulario de Inscripción</h1>
+        <p class="text-gray-600">Completa tus datos para unirte a nosotros.</p>
     </div>
+
+    {{ form_start(form, {'attr': {'class': 'bg-white p-6 rounded-lg shadow-md'}, 'enctype': 'multipart/form-data'}) }}
+
+    <div class="flex flex-col md:flex-row gap-6 mb-8">
+        <div class="w-full md:w-1/2 p-4 border border-gray-200 rounded-lg text-center bg-gray-50">
+            <h3 class="text-xl font-semibold mb-4 text-gray-800">Foto de Perfil</h3>
+            <div class="mb-4">
+                <div id="preview-element" class="w-32 h-32 rounded-full mx-auto bg-gray-300 flex items-center justify-center text-gray-600 text-sm mb-4 border-2 border-blue-300 shadow">
+                    Sin Foto
+                </div>
+            </div>
+            <div class="w-fit mx-auto">
+                {{ form_row(form.profilePicture, {
+                    label: 'Subir foto',
+                    attr: {
+                        'class': 'block text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none'
+                    }
+                }) }}
+            </div>
+            <p class="text-xs text-gray-500 mt-1">Sube una imagen JPG o PNG (máx. 1MB).</p>
+        </div>
+
+        <div class="w-full md:w-1/2 p-4 border border-gray-200 rounded-lg bg-gray-50">
+            <h3 class="text-xl font-semibold mb-4 text-gray-800">Datos Básicos</h3>
+            <div class="grid grid-cols-2 gap-x-6">
+                <div class="col-span-1">
+                    {{ form_row(form.name) }}
+                </div>
+                <div class="col-span-1">
+                    {{ form_row(form.lastName) }}
+                </div>
+                <div class="col-span-1 mt-4">
+                    {{ form_row(form.phone) }}
+                </div>
+                <div class="col-span-1 mt-4">
+                    {{ form_row(form.user.email) }}
+                </div>
+                <div class="col-span-1 mt-4">
+                    {{ form_row(form.dni) }}
+                </div>
+                <div class="col-span-1 mt-4">
+                    {{ form_row(form.dateOfBirth) }}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="w-full p-4 border border-gray-200 rounded-lg bg-white mb-8">
+        <h3 class="text-xl font-semibold mb-4 text-gray-800">Datos Detallados</h3>
+
+        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Dirección</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>{{ form_row(form.streetType) }}</div>
+            <div>{{ form_row(form.address) }}</div>
+            <div>{{ form_row(form.postalCode) }}</div>
+            <div>{{ form_row(form.province) }}</div>
+            <div>{{ form_row(form.city) }}</div>
+        </div>
+
+        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Información de Emergencia</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>{{ form_row(form.contactPerson1) }}</div>
+            <div>{{ form_row(form.contactPhone1) }}</div>
+            <div>{{ form_row(form.contactPerson2) }}</div>
+            <div>{{ form_row(form.contactPhone2) }}</div>
+        </div>
+
+        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Información Médica</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>{{ form_row(form.allergies) }}</div>
+        </div>
+
+        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Profesional y Cualificaciones</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>{{ form_row(form.profession) }}</div>
+            <div>{{ form_row(form.employmentStatus) }}</div>
+            <div>{{ form_row(form.drivingLicenses) }}</div>
+            <div>{{ form_row(form.drivingLicenseExpiryDate) }}</div>
+        </div>
+        <div class="mb-4">{{ form_row(form.navigationLicenses) }}</div>
+        <div class="mb-4">{{ form_row(form.specificQualifications) }}</div>
+        <div class="mb-4">{{ form_row(form.otherQualifications) }}</div>
+
+        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Otros Datos e Intereses</h2>
+        <div class="mb-4">{{ form_row(form.languages) }}</div>
+        <div class="mb-4">{{ form_row(form.motivation) }}</div>
+        <div class="mb-4">{{ form_row(form.howKnown) }}</div>
+        <div class="mb-4">{{ form_row(form.hasVolunteeredBefore) }}</div>
+        <div class="mb-4">{{ form_row(form.previousVolunteeringInstitutions) }}</div>
+
+        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Contraseña de Acceso</h2>
+        <p class="text-sm text-gray-600 mb-4">Elige una contraseña segura para acceder a la plataforma.</p>
+        <div class="mb-4">{{ form_row(form.user.password) }}</div>
+    </div>
+
+    <div class="flex items-center justify-end gap-3 mt-6">
+        <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-4 rounded-lg transition-colors">Completar Inscripción</button>
+    </div>
+
+    {{ form_end(form) }}
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const profilePictureInput = document.querySelector('input[type="file"][name$="[profilePicture]"]');
+        let previewElement = document.getElementById('preview-element');
+
+        if (profilePictureInput && previewElement) {
+            profilePictureInput.addEventListener('change', function (event) {
+                const file = event.target.files[0];
+                if (file) {
+                    const reader = new FileReader();
+                    reader.onload = function (e) {
+                        if (previewElement.tagName === 'DIV') {
+                            const newImg = document.createElement('img');
+                            newImg.id = 'preview-element';
+                            newImg.alt = 'Foto de perfil';
+                            newImg.className = 'w-32 h-32 rounded-full object-cover mx-auto border-2 border-blue-300 shadow mb-4';
+                            previewElement.parentNode.replaceChild(newImg, previewElement);
+                            previewElement = newImg;
+                        }
+                        previewElement.src = e.target.result;
+                    };
+                    reader.readAsDataURL(file);
+                }
+            });
+        }
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
This commit introduces a new public-facing layout and unifies the design of the volunteer registration and creation forms to improve user experience, based on user feedback.

Key changes include:
- A new `public.html.twig` layout has been created to provide a clean, sidebar-free view for public pages like the registration form and error pages.
- The 'Invalid Invitation' error page now uses the new public layout and has a more detailed, user-friendly message.
- The volunteer registration form (`/nueva_inscripcion`) now uses the public layout and has been redesigned to match the detailed, modern look of the 'Edit Volunteer' form.
- The admin-facing new volunteer form (`/nuevo_voluntario`) has also been updated to match this unified design, while retaining the admin sidebar for a consistent backend experience.