### PR TITLE
Fix: Remove sidebar from new volunteer registration form

### DIFF
--- a/templates/volunteer/registration_form.html.twig
+++ b/templates/volunteer/registration_form.html.twig
@@ -1,6 +1,6 @@
 {# templates/volunteer/registration_form.html.twig #}
 
-{% extends 'base.html.twig' %}
+{% extends 'layout/public.html.twig' %}
 
 {% block title %}Inscripción de Voluntarios{% endblock %}
 


### PR DESCRIPTION
The new volunteer registration form was inheriting the main application layout, which includes the admin sidebar. This is not desirable for a public-facing registration page.

This change modifies the `registration_form.html.twig` template to extend `layout/public.html.twig` instead of `base.html.twig`. The `public.html.twig` layout does not include the sidebar, providing a cleaner, more focused experience for new users filling out the form.