### PR TITLE
Fix: Use public layout for volunteer registration form

### DIFF
--- a/templates/volunteer/registration_form.html.twig
+++ b/templates/volunteer/registration_form.html.twig
@@ -1,6 +1,6 @@
 {# templates/volunteer/registration_form.html.twig #}
 
-{% extends 'layout/app.html.twig' %}
+{% extends 'layout/public.html.twig' %}
 
 {% block page_title %}Formulario de Inscripción de Nuevo Voluntario{% endblock %}
 


### PR DESCRIPTION
The new volunteer registration form was inheriting the main application layout, which includes the admin sidebar. This is not appropriate for a public-facing registration page.

This change modifies the `registration_form.html.twig` template to extend `layout/public.html.twig` instead of `layout/app.html.twig`. The `public.html.twig` layout does not include the sidebar, providing a cleaner and more focused experience for new users completing the form.