### PR TITLE
Fix: Improve public layout for volunteer registration form

### DIFF
--- a/templates/layout/public.html.twig
+++ b/templates/layout/public.html.twig
@@ -1,9 +1,9 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
-<div class="flex h-screen bg-gray-50 justify-center items-center">
+<div class="flex flex-col justify-center min-h-screen bg-gray-50 py-12 sm:px-6 lg:px-8">
     <!-- Main content -->
-    <div class="w-full max-w-4xl">
+    <div class="w-full max-w-4xl mx-auto">
         <!-- Main content area -->
         <main class="p-6">
             {% for message in app.flashes('success') %}


### PR DESCRIPTION
This commit addresses two issues with the public volunteer registration form:

1.  The form was incorrectly inheriting the main application layout (`layout/app.html.twig`), which includes the admin sidebar. This is not appropriate for a public-facing page. The template (`templates/volunteer/registration_form.html.twig`) has been updated to extend the correct public layout (`layout/public.html.twig`).

2.  The public layout was using flex properties (`items-center`) that caused long content to be vertically centered and cut off. The layout has been adjusted to use `min-h-screen` and vertical padding, ensuring that long forms are fully visible and scrollable.

These changes provide a cleaner, more professional, and fully functional user experience for new volunteers registering on the site.