### PR TITLE
Feat: Overhaul and redesign public volunteer registration form

### DIFF
--- a/templates/layout/public.html.twig
+++ b/templates/layout/public.html.twig
@@ -5,7 +5,7 @@
     <!-- Main content -->
     <div class="w-full max-w-6xl mx-auto">
         <!-- Main content area -->
-        <main class="p-6">
+        <main>
             {% for message in app.flashes('success') %}
                 <div class="mb-4 p-4 bg-green-50 border border-green-200 rounded-lg">
                     <div class="flex items-center">

--- a/templates/volunteer/registration_form.html.twig
+++ b/templates/volunteer/registration_form.html.twig
@@ -5,227 +5,197 @@
 {% block page_title %}Formulario de Inscripción de Nuevo Voluntario{% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-    <div class="text-center mb-8">
-        <img src="https://raw.githubusercontent.com/Carlos-casal/ssgv/main/public/images/logo.png" alt="Logo Protección Civil Vigo" class="w-32 mx-auto mb-4">
-        <h1 class="text-3xl font-bold text-gray-900">Formulario de Inscripción</h1>
-        <p class="text-gray-600">Completa tus datos para unirte a nosotros.</p>
+<div class="bg-white rounded-lg shadow-lg overflow-hidden">
+    {# Header con fondo azul y logo #}
+    <div class="bg-blue-600 p-6 sm:p-8 text-center">
+        <div class="inline-block bg-white p-2 rounded-full shadow-md">
+            <img src="https://raw.githubusercontent.com/Carlos-casal/ssgv/main/public/images/logo.png" alt="Logo Protección Civil Vigo" class="w-24 h-24">
+        </div>
+        <h1 class="text-3xl font-bold text-white mt-4">Formulario de Inscripción</h1>
+        <p class="text-blue-100">Completa tus datos para unirte a nosotros.</p>
     </div>
 
-    {# Mensajes flash #}
-    {% for message in app.flashes('success') %}
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ message }}</span>
-        </div>
-    {% endfor %}
-    {% for message in app.flashes('error') %}
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ message }}</span>
-        </div>
-    {% endfor %}
+    {# Contenido del formulario con padding #}
+    <div class="p-6 sm:p-8">
+        {# Mensajes flash #}
+        {% for message in app.flashes('success') %}
+            <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-6" role="alert">
+                <span class="block sm:inline">{{ message }}</span>
+            </div>
+        {% endfor %}
+        {% for message in app.flashes('error') %}
+            <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-6" role="alert">
+                <span class="block sm:inline">{{ message }}</span>
+            </div>
+        {% endfor %}
 
-    {# Contenedor principal del formulario con estilos #}
-    {{ form_start(form, {'attr': {'class': 'bg-white p-6 rounded-lg shadow-md'}, 'enctype': 'multipart/form-data'}) }}
+        {{ form_start(form, {'attr': {'class': 'space-y-8'}, 'enctype': 'multipart/form-data'}) }}
 
-    {# CONTENEDOR PRINCIPAL: Flex para la fila superior (foto + datos básicos) #}
-    <div class="flex flex-col md:flex-row gap-6 mb-8">
+        {# CONTENEDOR PRINCIPAL: Flex para la fila superior (foto + datos básicos) #}
+        <div class="flex flex-col md:flex-row gap-6">
+            {# Recuadro de la foto de perfil #}
+            <div class="w-full md:w-1/3 p-4 border border-gray-200 rounded-lg text-center bg-gray-50 self-start">
+                <h3 class="text-xl font-semibold mb-4 text-gray-800">Foto de Perfil</h3>
+                <div class="mb-4">
+                    <div id="preview-element" class="w-32 h-32 rounded-full mx-auto bg-gray-300 flex items-center justify-center text-gray-600 text-sm mb-4 border-2 border-blue-300 shadow">
+                        Sin Foto
+                    </div>
+                </div>
+                <div class="w-fit mx-auto">
+                    {{ form_row(form.profilePicture, {
+                        label: 'Subir foto',
+                        attr: {
+                            'class': 'block text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none'
+                        }
+                    }) }}
+                </div>
+                <p class="text-xs text-gray-500 mt-1">Sube una imagen JPG o PNG (máx. 1MB).</p>
+            </div>
 
-        {# Recuadro de la foto de perfil (Izquierda - md:w-1/2) #}
-        <div class="w-full md:w-1/2 p-4 border border-gray-200 rounded-lg text-center bg-gray-50">
-            <h3 class="text-xl font-semibold mb-4 text-gray-800">Foto de Perfil</h3>
-            <div class="mb-4">
-                {# ESTE ES EL DIV "SIN FOTO" VISIBLE INICIALMENTE #}
-                <div id="preview-element"
-                     class="w-32 h-32 rounded-full mx-auto bg-gray-300 flex items-center justify-center text-gray-600 text-sm mb-4 border-2 border-blue-300 shadow">
-                    Sin Foto
+            {# Recuadro de Datos Básicos #}
+            <div class="w-full md:w-2/3 p-4 border border-gray-200 rounded-lg bg-gray-50">
+                <h3 class="text-xl font-semibold mb-4 text-gray-800">Datos Básicos</h3>
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4">
+                    <div>
+                        {{ form_label(form.name, 'Nombre') }}
+                        {{ form_widget(form.name) }}
+                        {{ form_errors(form.name) }}
+                    </div>
+                    <div>
+                        {{ form_label(form.lastName, 'Apellidos') }}
+                        {{ form_widget(form.lastName) }}
+                        {{ form_errors(form.lastName) }}
+                    </div>
+                    <div>
+                        {{ form_label(form.phone, 'Teléfono de contacto') }}
+                        {{ form_widget(form.phone) }}
+                        {{ form_errors(form.phone) }}
+                    </div>
+                    <div>
+                        {{ form_label(form.user.email, 'Correo Electrónico') }}
+                        {{ form_widget(form.user.email) }}
+                        {{ form_errors(form.user.email) }}
+                    </div>
+                    <div>
+                        {{ form_label(form.dni, 'DNI') }}
+                        {{ form_widget(form.dni) }}
+                        {{ form_errors(form.dni) }}
+                    </div>
+                    <div>
+                        {{ form_label(form.dateOfBirth, 'Fecha de nacimiento') }}
+                        {{ form_widget(form.dateOfBirth) }}
+                        {{ form_errors(form.dateOfBirth) }}
+                    </div>
                 </div>
             </div>
-            {# El recuadro del input de archivo se mantiene estrecho y centrado #}
-            <div class="w-fit mx-auto">
-                {{ form_row(form.profilePicture, {
-                    label: 'Subir foto',
-                    attr: {
-                        'class': 'block text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none'
-                    }
-                }) }}
+        </div>
+
+        {# Recuadro con el Resto de Datos del Voluntario #}
+        <div class="p-4 border border-gray-200 rounded-lg bg-white">
+            <h3 class="text-xl font-semibold mb-4 text-gray-800">Datos Detallados del Voluntario</h3>
+
+            <div class="space-y-6">
+                {# Sección: Dirección #}
+                <fieldset>
+                    <legend class="text-lg font-semibold text-gray-800 border-b pb-2 mb-4 w-full">Dirección</legend>
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div>{{ form_row(form.streetType) }}</div>
+                        <div class="md:col-span-2">{{ form_row(form.address) }}</div>
+                        <div>{{ form_row(form.postalCode) }}</div>
+                        <div>{{ form_row(form.city) }}</div>
+                        <div>{{ form_row(form.province) }}</div>
+                    </div>
+                </fieldset>
+
+                {# Sección: Información de Emergencia #}
+                <fieldset>
+                    <legend class="text-lg font-semibold text-gray-800 border-b pb-2 mb-4 w-full">Información de Emergencia</legend>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>{{ form_row(form.contactPerson1) }}</div>
+                        <div>{{ form_row(form.contactPhone1) }}</div>
+                        <div>{{ form_row(form.contactPerson2) }}</div>
+                        <div>{{ form_row(form.contactPhone2) }}</div>
+                    </div>
+                </fieldset>
+
+                {# Sección: Información Médica #}
+                <fieldset>
+                    <legend class="text-lg font-semibold text-gray-800 border-b pb-2 mb-4 w-full">Información Médica</legend>
+                    {{ form_row(form.allergies) }}
+                </fieldset>
+
+                {# Sección: Profesional y Cualificaciones #}
+                <fieldset>
+                    <legend class="text-lg font-semibold text-gray-800 border-b pb-2 mb-4 w-full">Profesional y Cualificaciones</legend>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                        <div>{{ form_row(form.profession) }}</div>
+                        <div>{{ form_row(form.employmentStatus) }}</div>
+                    </div>
+                     <div class="mb-4">{{ form_row(form.drivingLicenses) }}</div>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                        <div>{{ form_row(form.drivingLicenseExpiryDate) }}</div>
+                        <div class="flex items-center h-full">{{ form_row(form.habilitadoConducir) }}</div>
+                    </div>
+                    <div class="mb-4">{{ form_row(form.navigationLicenses) }}</div>
+                    {{ form_row(form.otherQualifications) }}
+                </fieldset>
+
+                {# Sección: Otros Datos e Intereses #}
+                <fieldset>
+                    <legend class="text-lg font-semibold text-gray-800 border-b pb-2 mb-4 w-full">Otros Datos e Intereses</legend>
+                    <div class="mb-4">{{ form_row(form.languages) }}</div>
+                    <div class="mb-4">{{ form_row(form.motivation) }}</div>
+                    <div class="mb-4">{{ form_row(form.howKnown) }}</div>
+                    <div class="mb-4">{{ form_row(form.hasVolunteeredBefore) }}</div>
+                    {{ form_row(form.previousVolunteeringInstitutions) }}
+                </fieldset>
+
+                {# Contraseña de Acceso #}
+                <fieldset>
+                    <legend class="text-lg font-semibold text-gray-800 border-b pb-2 mb-4 w-full">Contraseña de Acceso</legend>
+                    <p class="text-sm text-gray-600 mb-4">Elige una contraseña segura para acceder a la plataforma. Las contraseñas deben coincidir.</p>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>{{ form_row(form.user.password.first) }}</div>
+                        <div>{{ form_row(form.user.password.second) }}</div>
+                    </div>
+                </fieldset>
             </div>
-            <p class="text-xs text-gray-500 mt-1">Sube una imagen JPG o PNG (máx. 1MB).</p>
         </div>
 
-        {# Recuadro de Datos Básicos (Derecha - md:w-1/2) #}
-        <div class="w-full md:w-1/2 p-4 border border-gray-200 rounded-lg bg-gray-50">
-            <h3 class="text-xl font-semibold mb-4 text-gray-800">Datos Básicos</h3>
-            <div class="grid grid-cols-2 gap-x-6">
-                <!-- Fila 1: Nombre y Apellidos -->
-                <div class="col-span-1">
-                    {{ form_label(form.name, 'Nombre') }}
-                    {{ form_widget(form.name, {'attr': {'class': 'w-full'}}) }}
-                    {{ form_errors(form.name) }}
-                </div>
-                <div class="col-span-1">
-                    {{ form_label(form.lastName, 'Apellidos') }}
-                    {{ form_widget(form.lastName, {'attr': {'class': 'w-full'}}) }}
-                    {{ form_errors(form.lastName) }}
-                </div>
-
-                <!-- Fila 2: Teléfono y Correo -->
-                <div class="col-span-1 mt-4">
-                    {{ form_label(form.phone, 'Teléfono de contacto') }}
-                    {{ form_widget(form.phone, {'attr': {'class': 'w-full'}}) }}
-                    {{ form_errors(form.phone) }}
-                </div>
-                <div class="col-span-1 mt-4">
-                    {{ form_label(form.user.email, 'Correo') }}
-                    {{ form_widget(form.user.email, {'attr': {'class': 'w-full'}}) }}
-                    {{ form_errors(form.user.email) }}
-                </div>
-
-                <!-- Fila 3: DNI y Fecha de Nacimiento -->
-                <div class="col-span-1 mt-4">
-                    {{ form_label(form.dni, 'DNI') }}
-                    {{ form_widget(form.dni, {'attr': {'class': 'w-full'}}) }}
-                    {{ form_errors(form.dni) }}
-                </div>
-                <div class="col-span-1 mt-4">
-                    {{ form_label(form.dateOfBirth, 'Fecha de nacimiento') }}
-                    {{ form_widget(form.dateOfBirth, {'attr': {'class': 'w-full'}}) }}
-                    {{ form_errors(form.dateOfBirth) }}
-                </div>
-
-            </div>
+        <div class="flex items-center justify-end gap-3 mt-6">
+            <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-4 rounded-lg transition-colors shadow-md">Completar Inscripción</button>
         </div>
+
+        {{ form_end(form) }}
     </div>
-
-    {# Recuadro con el Resto de Datos del Voluntario (debajo de la fila superior, ocupa todo el ancho) #}
-    <div class="w-full p-4 border border-gray-200 rounded-lg bg-white mb-8">
-        <h3 class="text-xl font-semibold mb-4 text-gray-800">Datos Detallados del Voluntario</h3>
-
-        {# Sección: Dirección #}
-        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Dirección</h2>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>{{ form_row(form.streetType) }}</div>
-            <div>{{ form_row(form.address) }}</div>
-            <div>{{ form_row(form.postalCode) }}</div>
-            <div>{{ form_row(form.province) }}</div>
-            <div>{{ form_row(form.city) }}</div>
-        </div>
-
-        {# Sección: Información de Emergencia #}
-        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Información de Emergencia</h2>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>{{ form_row(form.contactPerson1) }}</div>
-            <div>{{ form_row(form.contactPhone1) }}</div>
-            <div>{{ form_row(form.contactPerson2) }}</div>
-            <div>{{ form_row(form.contactPhone2) }}</div>
-        </div>
-
-        {# Sección: Información Médica #}
-        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Información Médica</h2>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>{{ form_row(form.allergies) }}</div>
-        </div>
-
-        {# Sección: Información Profesional y Cualificaciones #}
-        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Profesional y Cualificaciones</h2>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>{{ form_row(form.profession) }}</div>
-            <div>{{ form_row(form.employmentStatus) }}</div>
-            <div>{{ form_row(form.drivingLicenses) }}</div>
-            <div>{{ form_row(form.drivingLicenseExpiryDate) }}</div>
-            <div class="col-span-2">{{ form_row(form.habilitadoConducir) }}</div>
-        </div>
-        <div class="mb-4">
-            {{ form_row(form.navigationLicenses) }}
-        </div>
-        <div class="mb-4">
-            {{ form_row(form.otherQualifications) }}
-        </div>
-
-        {# Sección: Otros Datos e Intereses #}
-        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Otros Datos e Intereses</h2>
-        <div class="mb-4">
-            {{ form_row(form.languages) }}
-        </div>
-        <div class="mb-4">
-            {{ form_row(form.motivation) }}
-        </div>
-        <div class="mb-4">
-            {{ form_row(form.howKnown) }}
-        </div>
-        <div class="mb-4">
-            {{ form_row(form.hasVolunteeredBefore) }}
-        </div>
-        <div class="mb-4">
-            {{ form_row(form.previousVolunteeringInstitutions) }}
-        </div>
-
-        {# Contraseña (obligatoria para el registro) #}
-        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Contraseña de Acceso</h2>
-        <p class="text-sm text-gray-600 mb-4">Elige una contraseña segura para acceder a la plataforma. Las contraseñas deben coincidir.</p>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>{{ form_row(form.user.password.first) }}</div>
-            <div>{{ form_row(form.user.password.second) }}</div>
-        </div>
-    </div>
-
-    <div class="flex items-center justify-end gap-3 mt-6">
-        <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-4 rounded-lg transition-colors">Completar Inscripción</button>
-    </div>
-
-    {{ form_end(form) }}
 </div>
 
-{# INICIO DEL BLOQUE DE JAVASCRIPT - ADAPTADO PARA REEMPLAZAR DIV POR IMG #}
+{# Bloque de JavaScript para la previsualización de la imagen #}
 <script>
     document.addEventListener('DOMContentLoaded', function() {
-        // Selecciona el input de archivo por su tipo y parte del atributo 'name'
         const profilePictureInput = document.querySelector('input[type="file"][name$="[profilePicture]"]');
-        // Usamos 'let' para la previsualización porque su referencia podría cambiar (de div a img)
         let previewElement = document.getElementById('preview-element');
 
         if (profilePictureInput && previewElement) {
             profilePictureInput.addEventListener('change', function (event) {
                 const file = event.target.files[0];
-
                 if (file) {
                     const reader = new FileReader();
-
                     reader.onload = function (e) {
-                        // Si el elemento de previsualización actual es un DIV (el "Sin Foto"),
-                        // lo reemplazamos por una nueva etiqueta IMG.
                         if (previewElement.tagName === 'DIV') {
                             const newImg = document.createElement('img');
-                            newImg.id = 'preview-element'; // Mantiene el mismo ID
+                            newImg.id = 'preview-element';
                             newImg.alt = 'Foto de perfil';
-                            // Copia las clases para mantener el estilo circular y responsivo
-                            newImg.className = 'w-32 h-32 rounded-full object-cover mx-auto border-2 border-blue-300 shadow mb-4';
+                            newImg.className = 'w-32 h-32 rounded-full object-cover mx-auto border-2 border-blue-300 shadow';
                             previewElement.parentNode.replaceChild(newImg, previewElement);
-                            previewElement = newImg; // Actualiza la referencia al nuevo elemento IMG
+                            previewElement = newImg;
                         }
-                        // Establece la fuente de la imagen
                         previewElement.src = e.target.result;
                     };
-                    reader.onerror = function(e) {
-                        console.error('Error al leer el archivo:', e);
-                    };
                     reader.readAsDataURL(file);
-                } else {
-                    // Si no se selecciona ningún archivo o se cancela,
-                    // y el elemento actual es una IMG, lo revertimos a un DIV "Sin Foto".
-                    if (previewElement.tagName === 'IMG') {
-                        const newDiv = document.createElement('div');
-                        newDiv.id = 'preview-element'; // Mantiene el mismo ID
-                        newDiv.className = 'w-32 h-32 rounded-full mx-auto bg-gray-300 flex items-center justify-center text-gray-600 text-sm mb-4 border-2 border-blue-300 shadow';
-                        newDiv.textContent = 'Sin Foto';
-                        previewElement.parentNode.replaceChild(newDiv, previewElement);
-                        previewElement = newDiv; // Actualiza la referencia al nuevo elemento DIV
-                    }
                 }
             });
-        } else {
-            console.error("ERROR: Elementos de previsualización o input de archivo no encontrados.");
         }
     });
 </script>
-{# FIN DEL BLOQUE DE JAVASCRIPT #}
 {% endblock %}


### PR DESCRIPTION
This commit completely revamps the public volunteer registration form based on multiple rounds of user feedback.

The following changes have been implemented:

1.  **Layout and Styling:**
    - The form now extends the `layout/public.html.twig` template, removing the admin sidebar for a clean, public-facing view.
    - The public layout has been modified to be wider (`max-w-6xl`) and to handle long, scrollable content correctly by using `min-h-screen` and vertical padding instead of centering.

2.  **Header Redesign:**
    - A new header with a `bg-blue-600` background has been added to the top of the registration form.
    - The logo is now placed inside a circular white container with a shadow, making it stand out against the blue background.
    - The logo's `src` has been updated to the correct URL.

3.  **Form Field Modifications:**
    - The `Número Identificación`, `Indicativo`, `Rol`, `Especialización`, and `Titulaciones Específicas` fields have been removed from both the `VolunteerType` form and the Twig template.
    - The `UserType` form now uses a `RepeatedType` for the password, providing "Contraseña" and "Repetir Contraseña" fields with automatic validation to ensure they match.

4.  **Entity and Default Values:**
    - In the `Volunteer` entity, the `hasVolunteeredBefore` property now defaults to `false`, which correctly sets the corresponding radio button in the form to 'No' by default.