### PR TITLE
Feat: Overhaul and redesign public volunteer registration form

### DIFF
--- a/templates/volunteer/new_volunteer.html.twig
+++ b/templates/volunteer/new_volunteer.html.twig
@@ -85,11 +85,6 @@
         <div class="mb-4">{{ form_row(form.hasVolunteeredBefore) }}</div>
         <div class="mb-4">{{ form_row(form.previousVolunteeringInstitutions) }}</div>
 
-        <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Rol y Especialización</h2>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>{{ form_row(form.role) }}</div>
-            <div>{{ form_row(form.specialization) }}</div>
-        </div>
 
         <h2 class="text-lg font-semibold mt-6 mb-4 text-gray-800 border-b pb-2">Contraseña</h2>
         <div class="mb-4">{{ form_row(form.user.password) }}</div>


### PR DESCRIPTION
This commit completely revamps the public volunteer registration form based on multiple rounds of user feedback.

The following changes have been implemented:

1.  **Layout and Styling:**
    - The form now extends the `layout/public.html.twig` template, removing the admin sidebar for a clean, public-facing view.
    - The public layout has been modified to be wider (`max-w-6xl`) and to handle long, scrollable content correctly by using `min-h-screen` and vertical padding instead of centering.

2.  **Header Redesign:**
    - A new header with a `bg-blue-600` background has been added to the top of the registration form.
    - The logo is now placed inside a circular white container with a shadow, making it stand out against the blue background.
    - The logo's `src` has been updated to the correct URL.

3.  **Form Field Modifications:**
    - The `Número Identificación`, `Indicativo`, `Rol`, `Especialización`, and `Titulaciones Específicas` fields have been removed from both the `VolunteerType` form and the corresponding Twig templates (`registration_form.html.twig` and `new_volunteer.html.twig`). This also resolves bugs where the admin 'new volunteer' page would crash.
    - The `UserType` form now uses a `RepeatedType` for the password, providing "Contraseña" and "Repetir Contraseña" fields with automatic validation to ensure they match.

4.  **Entity and Default Values:**
    - In the `Volunteer` entity, the `hasVolunteeredBefore` property now defaults to `false`, which correctly sets the corresponding radio button in the form to 'No' by default.