### PR TITLE
Fix(Volunteer): Resolve NotNullConstraintViolation for user email

### DIFF
--- a/src/Controller/VolunteerController.php
+++ b/src/Controller/VolunteerController.php
@@ -130,6 +130,9 @@ class VolunteerController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            // CORRECTO: Obtener el User del Volunteer hidratado por el formulario
+            $user = $volunteer->getUser();
+
             $plainPassword = $form->get('user')->get('password')->getData();
 
             if ($plainPassword) { // Solo hashear si se proporcionó una contraseña
@@ -180,7 +183,6 @@ class VolunteerController extends AbstractController
                 $volunteer->setJoinDate(new \DateTime());
             }
 
-            $entityManager->persist($user);
             $entityManager->persist($volunteer);
             $entityManager->flush();
 


### PR DESCRIPTION
This commit fixes a critical bug that caused a `NotNullConstraintViolationException` when creating a new volunteer through the admin interface. The error occurred because the `User` entity was being persisted with a null email.

The root cause was that the controller was attempting to persist a newly instantiated, empty `User` object instead of the one that was correctly hydrated with data from the submitted form.

The fix involves two key changes in `VolunteerController::new()`:
1. After the form is submitted and validated, the correctly populated `User` object is now retrieved from the `Volunteer` entity (`$user = $volunteer->getUser();`).
2. The explicit `$entityManager->persist($user);` call has been removed. The persistence of the `User` is now correctly handled by the `cascade={"persist"}` option on the `Volunteer` entity's `user` association, simplifying the code and adhering to Doctrine best practices.