### PR TITLE
Fix(Volunteer): Resolve creation errors for User email and Volunteer …

### DIFF
--- a/src/Controller/VolunteerController.php
+++ b/src/Controller/VolunteerController.php
@@ -183,6 +183,11 @@ class VolunteerController extends AbstractController
                 $volunteer->setJoinDate(new \DateTime());
             }
 
+            // Establecer rol por defecto si no está definido
+            if (!$volunteer->getRole()) {
+                $volunteer->setRole('Voluntario');
+            }
+
             $entityManager->persist($volunteer);
             $entityManager->flush();
 


### PR DESCRIPTION
…role

This commit addresses two critical `NotNullConstraintViolationException` errors that occurred during the creation of a new volunteer from the admin interface.

1.  **User Email Violation:** The initial error was that the `User` entity was being persisted with a null email. The controller was attempting to save a new, empty `User` object instead of the one hydrated by the form. This has been fixed by retrieving the populated `User` object from the `Volunteer` entity after form submission (`$user = $volunteer->getUser();`). The explicit `$entityManager->persist($user);` call was removed, as persistence is correctly handled by the `cascade={"persist"}` option on the `Volunteer`'s `user` association.

2.  **Volunteer Role Violation:** After fixing the email issue, a second error emerged where the `Volunteer` entity's `role` field was null. This has been resolved by setting a default role of 'Voluntario' in the controller's `new` action before the entity is persisted.

These changes ensure that new volunteers and their associated user accounts are created successfully without violating database constraints.