### PR TITLE
Feat: Increase logo size on login page

### DIFF
--- a/jules-scratch/verification/verify_logo_size.py
+++ b/jules-scratch/verification/verify_logo_size.py
@@ -1,0 +1,21 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run_verification():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+
+        # 1. Navigate to the login page
+        page.goto("http://localhost:5173/")
+
+        # 2. Wait for the logo image to be visible to ensure the page has loaded
+        logo = page.get_by_alt_text("Logo Protección Civil Vigo")
+        expect(logo).to_be_visible()
+
+        # 3. Take a screenshot to visually verify the new logo size
+        page.screenshot(path="jules-scratch/verification/verification.png")
+
+        browser.close()
+
+if __name__ == "__main__":
+    run_verification()

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -6,7 +6,7 @@
 <div class="min-h-screen bg-gradient-to-br from-sky-200 via-sky-300 to-sky-400 flex items-center justify-center p-4">
     <div class="max-w-md w-full">
         <div class="text-center mb-8">
-            <img src="https://raw.githubusercontent.com/Carlos-casal/ssgv/main/public/images/logo.png" alt="Logo Protección Civil Vigo" class="mx-auto h-24 w-auto mb-4">
+            <img src="https://raw.githubusercontent.com/Carlos-casal/ssgv/main/public/images/logo.png" alt="Logo Protección Civil Vigo" class="mx-auto h-32 w-auto mb-4">
             <h1 class="text-3xl font-bold text-gray-800 mb-2">Protección Civil de Vigo</h1>
             <p class="text-gray-600">Sistema de Gestión</p>
         </div>


### PR DESCRIPTION
This commit increases the size of the logo on the login page as requested by the user.

The height of the logo's `<img>` element in `templates/security/login.html.twig` has been increased by changing the Tailwind CSS class from `h-24` to `h-32`. This makes the logo more prominent on the page.