### PR TITLE
Feat: Update page title and set global favicon

### DIFF
--- a/jules-scratch/verification/verify_title_and_favicon.py
+++ b/jules-scratch/verification/verify_title_and_favicon.py
@@ -1,0 +1,31 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run_verification():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+
+        # 1. Verify the login page
+        page.goto("http://localhost:5173/")
+
+        # Assert the new title is correct
+        expect(page).to_have_title("Iniciar Sesión - PC Vigo")
+
+        # Take a screenshot to verify the favicon on the login page
+        page.screenshot(path="jules-scratch/verification/login_page_verification.png")
+
+        # 2. Log in to verify the favicon on an authenticated page
+        page.get_by_label("Correo electrónico").fill("admin@voluntarios.org")
+        page.get_by_label("Contraseña").fill("admin123")
+        page.get_by_role("button", name="Iniciar Sesión").click()
+
+        # Wait for the dashboard to load
+        expect(page.get_by_role("heading", name="¡Bienvenido al Sistema de Gestión!")).to_be_visible()
+
+        # Take a screenshot to verify the favicon on the dashboard
+        page.screenshot(path="jules-scratch/verification/dashboard_page_verification.png")
+
+        browser.close()
+
+if __name__ == "__main__":
+    run_verification()

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <title>{% block title %}Sistema de Gestión de Voluntarios{% endblock %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text></svg>">
+        <link rel="icon" href="https://raw.githubusercontent.com/Carlos-casal/ssgv/main/public/images/logo.png" type="image/png">
         <script src="https://cdn.tailwindcss.com"></script>
         {% block stylesheets %}{% endblock %}
         <link href="https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.snow.css" rel="stylesheet">

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Iniciar Sesión - Sistema de Gestión de Voluntarios{% endblock %}
+{% block title %}Iniciar Sesión - PC Vigo{% endblock %}
 
 {% block body %}
 <div class="min-h-screen bg-gradient-to-br from-sky-200 via-sky-300 to-sky-400 flex items-center justify-center p-4">


### PR DESCRIPTION
This commit implements two user-requested changes to the application's branding in the browser tab:

1.  **Login Page Title:** The title of the login page has been updated to "Iniciar Sesión - PC Vigo". This was done by modifying the `{% block title %}` in `templates/security/login.html.twig`.

2.  **Global Favicon:** The application now uses the Protección Civil logo as the favicon on all pages. This was achieved by updating the `<link rel="icon">` tag in the base template file, `templates/base.html.twig`, to point to the correct logo URL.