### PR TITLE
Feat: Improve Dashboard Modal, Indicativo Field, and Login UI

### DIFF
--- a/src/Controller/VolunteerController.php
+++ b/src/Controller/VolunteerController.php
@@ -125,15 +125,7 @@ class VolunteerController extends AbstractController
             $user->setEmail($emailFromQuery);
         }
 
-        $usedIndicativos = $volunteerRepository->findUsedIndicativos();
-        $highestEverIndicativo = $volunteerRepository->findHighestIndicativo();
-
-        // The range should go up to at least 50, or the highest number ever used.
-        $maxRange = max(50, $highestEverIndicativo);
-        $allPossibleIndicativos = range(1, $maxRange);
-
-        $usedNumericIndicativos = array_map('intval', array_filter($usedIndicativos, 'is_numeric'));
-        $availableIndicativos = array_diff($allPossibleIndicativos, $usedNumericIndicativos);
+        $availableIndicativos = $volunteerRepository->findAvailableIndicativos();
 
         $form = $this->createForm(VolunteerType::class, $volunteer, [
             'available_indicativos' => $availableIndicativos,
@@ -308,19 +300,7 @@ class VolunteerController extends AbstractController
             return $this->redirectToRoute('app_volunteer_list');
         }
 
-        $usedIndicativos = $volunteerRepository->findUsedIndicativos();
-        $currentIndicativo = $volunteer->getIndicativo();
-
-        if ($currentIndicativo && ($key = array_search($currentIndicativo, $usedIndicativos)) !== false) {
-            unset($usedIndicativos[$key]);
-        }
-
-        $highestEverIndicativo = $volunteerRepository->findHighestIndicativo();
-        $maxRange = max(50, $highestEverIndicativo);
-        $allPossibleIndicativos = range(1, $maxRange);
-
-        $usedNumericIndicativos = array_map('intval', array_filter($usedIndicativos, 'is_numeric'));
-        $availableIndicativos = array_diff($allPossibleIndicativos, $usedNumericIndicativos);
+        $availableIndicativos = $volunteerRepository->findAvailableIndicativos();
 
         $form = $this->createForm(VolunteerType::class, $volunteer, [
             'is_edit' => true,

--- a/src/Repository/VolunteerRepository.php
+++ b/src/Repository/VolunteerRepository.php
@@ -128,44 +128,20 @@ class VolunteerRepository extends ServiceEntityRepository
     }
 
     /**
-     * Finds all used 'indicativo' numbers from volunteers who are not inactive.
-     * This includes active, suspended, and pending volunteers.
+     * Finds all indicativo numbers from inactive ('Baja') volunteers that can be reused.
      * @return string[]
      */
-    public function findUsedIndicativos(): array
+    public function findAvailableIndicativos(): array
     {
         $qb = $this->createQueryBuilder('v')
             ->select('v.indicativo')
             ->where('v.indicativo IS NOT NULL')
-            ->andWhere('v.status != :status')
+            ->andWhere('v.status = :status')
             ->setParameter('status', Volunteer::STATUS_INACTIVE)
             ->orderBy('v.indicativo', 'ASC');
 
         $result = $qb->getQuery()->getScalarResult();
 
         return array_map('current', $result);
-    }
-
-    /**
-     * Finds the highest numeric indicativo value in the table.
-     * @return int
-     */
-    public function findHighestIndicativo(): int
-    {
-        $qb = $this->createQueryBuilder('v')
-            ->select('v.indicativo')
-            ->where('v.indicativo IS NOT NULL')
-            ->orderBy('LENGTH(v.indicativo)', 'DESC')
-            ->addOrderBy('v.indicativo', 'DESC')
-            ->setMaxResults(1);
-
-        $result = $qb->getQuery()->getOneOrNullResult();
-
-        // Return 0 if no indicativo is found
-        if (!$result || !is_numeric($result['indicativo'])) {
-            return 0;
-        }
-
-        return (int) $result['indicativo'];
     }
 }


### PR DESCRIPTION
This commit implements three key improvements based on user feedback:

1.  **Dashboard Modal Fix:** The 'Add Volunteer' modal on the admin dashboard has been refactored from vanilla JavaScript into a Stimulus controller. This resolves a bug where the modal would only open after a full page refresh, ensuring it now works reliably with Turbo-driven navigations.

2.  **Enhanced 'Indicativo' Field:** The 'indicativo' field for volunteers now correctly suggests numbers from inactive ('de baja') volunteers. This allows for easy reuse of available numbers while still permitting manual entry.

3.  **Login Page Redesign:** The login page UI has been updated.
    - The background is now a subtle, light blue (`bg-sky-100`).
    - The application logo has been enlarged for better visibility while maintaining the overall layout.