### PR TITLE
Feat: Overhaul volunteer form and implement multiple enhancements

### DIFF
--- a/src/Form/VolunteerType.php
+++ b/src/Form/VolunteerType.php
@@ -13,7 +13,11 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use App\Form\UserType;
 use Symfony\Component\Form\Extension\Core\Type\FileType; // ¡AÑADE ESTA LÍNEA!
-use Symfony\Component\Validator\Constraints\File; // ¡AÑADE ESTA LÍNEA!
+use Symfony\Component\Validator\Constraints\File;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
  * Form type for creating and editing Volunteer profiles.
@@ -31,11 +35,6 @@ class VolunteerType extends AbstractType
      * @param FormBuilderInterface $builder The form builder.
      * @param array $options The options for building the form, including a custom 'is_edit' option.
      */
-use Symfony\Component\Form\Extension\Core\Type\EmailType;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Validator\Constraints\NotBlank;
-
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder


### PR DESCRIPTION
This commit delivers a comprehensive overhaul of the new volunteer form and implements several other user-requested features, including a fix for the dashboard modal and a redesign of the login page.

**New Volunteer Form ("Alta Voluntario"):**
- **Complete Redesign:** The form at `templates/volunteer/new_volunteer.html.twig` has been rebuilt with a modern, two-column layout for improved usability.
- **Mandatory Fields & Validation:** All specified fields are now mandatory. Backend validation (`Assert`) has been added to the `Volunteer` entity for:
    - Age check (>16 years) for `dateOfBirth`.
    - International phone number format.
    - Uniqueness of the `indicativo` field.
- **Conditional Logic:** The form now uses `FormEvents` to conditionally require:
    - `drivingLicenseExpiryDate` if a driving license is selected.
    - `previousVolunteeringInstitutions` if the user indicates they have prior experience.
- **Real-time Frontend Validation:** A new Stimulus controller (`form_validation_controller.js`) provides immediate user feedback:
    - Fields are outlined in green (valid) or red (invalid).
    - Error messages are displayed dynamically.
    - Conditional fields are shown/hidden instantly.
- **Automatic Password & Role:** The `VolunteerController` now auto-generates a secure password and sets the default role to "Voluntario", removing these fields from the form.
- **Field Updates:**
    - "Allergies" has been split into "Food Allergies" and "Other Allergies".
    - `specificQualifications` field has been re-added for professional titles.

**Other Enhancements:**
- **Dashboard Modal Fix:** The "Add Volunteer" modal on the dashboard is now powered by a Stimulus controller (`modal_controller.js`), fixing a bug where it only worked after a page refresh.
- **Login Page Redesign:** The login page (`login.html.twig`) now has a light blue background and a larger logo.
- **Indicativo Suggestions:** The form now correctly suggests available `indicativo` numbers from inactive volunteers.