### PR TITLE
feat: Update volunteer registration URL to be inclusive

### DIFF
--- a/src/Controller/VolunteerController.php
+++ b/src/Controller/VolunteerController.php
@@ -112,7 +112,7 @@ class VolunteerController extends AbstractController
      * @param UserPasswordHasherInterface $userPasswordHasher The password hasher service.
      * @return Response The response object, rendering the new volunteer form or redirecting on success.
      */
-    #[Route('/alta-voluntariado', name: 'app_volunteer_new', methods: ['GET', 'POST'])]
+    #[Route('/alta-voluntari@', name: 'app_volunteer_new', methods: ['GET', 'POST'])]
     #[Security("is_granted('ROLE_ADMIN')")]
     public function new(Request $request, EntityManagerInterface $entityManager, UserPasswordHasherInterface $userPasswordHasher, VolunteerRepository $volunteerRepository): Response
     {


### PR DESCRIPTION
This commit changes the URL for the new volunteer registration page from `/alta-voluntariado` to `/alta-voluntari@` to use more inclusive language, as requested by the user.

The route in `VolunteerController` has been updated, and the corresponding view template already uses the inclusive term "Alta Voluntari@" for the page title.