### PR TITLE
feat: Update volunteer form with inclusive language and field changes

### DIFF
--- a/templates/volunteer/new_volunteer.html.twig
+++ b/templates/volunteer/new_volunteer.html.twig
@@ -17,15 +17,7 @@
             <div class="relative">{{ form_row(form.dateOfBirth, {'attr': {'data-action': 'change->form-validation#validate'}}) }}</div>
             <div class="relative">{{ form_row(form.phone, {'attr': {'data-action': 'blur->form-validation#validate'}}) }}</div>
             <div class="relative">{{ form_row(form.email, {'attr': {'data-action': 'blur->form-validation#validate'}}) }}</div>
-            <div class="relative">
-                {{ form_label(form.indicativo) }}
-                {{ form_widget(form.indicativo) }}
-                <datalist id="indicativos-list">
-                    {% for indicativo in available_indicativos %}
-                        <option value="{{ indicativo }}">
-                    {% endfor %}
-                </datalist>
-            </div>
+            <div class="relative">{{ form_row(form.profession, {'attr': {'data-action': 'blur->form-validation#validate'}}) }}</div>
         </div>
     </div>
 


### PR DESCRIPTION
This commit incorporates two user requests:

1.  Updates the new volunteer registration URL from `/alta-voluntariado` to `/alta-voluntari@` to use more inclusive language. The route in `VolunteerController` has been updated accordingly.

2.  Modifies the "Datos Personales" (Personal Data) section of the new volunteer form (`templates/volunteer/new_volunteer.html.twig`). The `indicativo` (call sign) field has been removed, and the `profession` field has been added in its place to better suit the required information.