### PR TITLE
feat(form): Modernize input field styling

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -18,19 +18,17 @@
 }
 
 @layer components {
-    /* Scoped styles for the new volunteer form */
-    .form-modern .form-field {
-        @apply w-full bg-transparent px-1 py-2 pl-8; /* Add left padding for icon */
-        @apply border-0 border-b-2 border-gray-300;
-        @apply focus:outline-none focus:ring-0 focus:border-blue-600;
-        @apply transition duration-150 ease-in-out;
+    /* Estilo moderno para campos de formulario */
+    .form-input-modern {
+        @apply w-full border-2 border-black rounded-lg px-3 py-2 transition-colors duration-200;
+        @apply focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500;
     }
 
-    .form-modern textarea.form-field {
-        @apply min-h-[80px];
+    /* Asegurarse de que los textareas tengan una altura mínima */
+    .form-input-modern.textarea {
+        @apply min-h-[100px];
     }
 
-@layer components {
     .is-valid {
         @apply border-green-500 focus:ring-green-500 focus:border-green-500;
     }

--- a/src/Form/VolunteerType.php
+++ b/src/Form/VolunteerType.php
@@ -211,6 +211,36 @@ class VolunteerType extends AbstractType
             ])
         ;
 
+        // --- Aplicar clases CSS a los campos apropiados ---
+        foreach ($builder->all() as $child) {
+            $config = $child->getOptions();
+            $type = get_class($child->getType()->getInnerType());
+
+            // Lista de tipos de campo a los que queremos aplicar el estilo
+            $textualInputTypes = [
+                TextType::class,
+                EmailType::class,
+                TextareaType::class,
+                DateType::class,
+            ];
+
+            // Aplicar solo a tipos de campo textuales y a ChoiceType no expandidos
+            $isApplicableChoice = ($type === ChoiceType::class && ($config['expanded'] ?? false) === false);
+
+            if (in_array($type, $textualInputTypes) || $isApplicableChoice) {
+                $attr = $config['attr'] ?? [];
+                // Usamos trim para evitar dobles espacios si la clase ya existía
+                $attr['class'] = trim(($attr['class'] ?? '') . ' form-input-modern');
+
+                if ($type === TextareaType::class) {
+                    $attr['class'] .= ' textarea';
+                }
+
+                // Volver a añadir el campo con la configuración actualizada
+                $builder->add($child->getName(), $type, array_merge($config, ['attr' => $attr]));
+            }
+        }
+
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $data = $event->getData();
             $form = $event->getForm();


### PR DESCRIPTION
This commit introduces a new, modern design for the input fields in the 'Alta Voluntari@' registration form.

- A new CSS utility class, `.form-input-modern`, has been added to `assets/styles/app.css` to define a consistent style with a 2px black border, 8px rounded corners, and internal padding for form inputs, selects, and textareas.
- The `src/Form/VolunteerType.php` class has been updated to programmatically apply this new class to all appropriate fields. This approach ensures consistency and maintainability by avoiding manual class additions in the Twig template.