### PR TITLE
feat: simplify service numeration and add real-time suggestion

### DIFF
--- a/assets/controllers/service_form_controller.js
+++ b/assets/controllers/service_form_controller.js
@@ -62,7 +62,10 @@ export default class extends Controller {
             const startInput = this.hasStartDateInputTarget ? this.startDateInputTarget : (document.getElementById('service_form_startDate') || document.getElementById('service_startDate'));
             const endInput = this.hasEndDateInputTarget ? this.endDateInputTarget : (document.getElementById('service_form_endDate') || document.getElementById('service_endDate'));
             if (startInput && endInput) {
-                startInput.addEventListener('input', () => this.updateAllMaterialAvailability());
+                startInput.addEventListener('input', () => {
+                    this.updateAllMaterialAvailability();
+                    this.suggestNumeration();
+                });
                 endInput.addEventListener('input', () => this.updateAllMaterialAvailability());
             }
 
@@ -124,6 +127,7 @@ export default class extends Controller {
             if (typeSelect && typeSelect.value && subcategorySelect && subcategorySelect.options.length <= 1) {
                 console.log("Triggering initial category load...");
                 this.updateCategories();
+                this.suggestNumeration();
             }
 
             console.log("Service Form: Unit prototypes cleaned.");
@@ -168,6 +172,9 @@ export default class extends Controller {
     // Unified Hierarchy Logic
     async updateCategories(event) {
         console.log("Updating categories action triggered", event);
+
+        // Also suggest numeration when type changes
+        this.suggestNumeration();
 
         // Comprehensive selector discovery
         let typeSelect = null;
@@ -1146,6 +1153,47 @@ export default class extends Controller {
             if (firstError) {
                 firstError.scrollIntoView({ behavior: 'smooth', block: 'center' });
             }
+        }
+    }
+
+    async suggestNumeration() {
+        if (!this.hasNumerationTarget) return;
+
+        // Don't overwrite if user already typed something manually
+        if (this.numerationTarget.value && this.numerationTarget.dataset.manual === "true") return;
+
+        const typeSelect = this.hasTypeSelectTarget ? this.typeSelectTarget : (document.getElementById('service_form_type') || document.getElementById('service_type'));
+        const startDateInput = this.hasStartDateInputTarget ? this.startDateInputTarget : (document.getElementById('service_form_startDate') || document.getElementById('service_startDate'));
+
+        const typeId = typeSelect?.value;
+        const date = startDateInput?.value;
+
+        if (!typeId) return;
+
+        try {
+            const response = await fetch(`/api/service/next-numeration?type_id=${typeId}&date=${date || ''}`);
+            if (!response.ok) throw new Error('Failed to fetch suggested numeration');
+            const data = await response.json();
+
+            if (data.suggestedId) {
+                // We set it as a placeholder and also as value if empty
+                this.numerationTarget.placeholder = data.suggestedId;
+                if (!this.numerationTarget.value) {
+                    this.numerationTarget.value = data.suggestedId;
+                    this.numerationTarget.classList.add('text-blue-600', 'font-bold');
+                }
+            }
+        } catch (error) {
+            console.error('Error suggesting numeration:', error);
+        }
+
+        // Add listener to mark as manual if user edits it
+        if (!this.numerationTarget.dataset.listenerSet) {
+            this.numerationTarget.addEventListener('input', () => {
+                this.numerationTarget.dataset.manual = "true";
+                this.numerationTarget.classList.remove('text-blue-600', 'font-bold');
+            });
+            this.numerationTarget.dataset.listenerSet = "true";
         }
     }
 

--- a/src/Controller/ServiceController.php
+++ b/src/Controller/ServiceController.php
@@ -756,4 +756,27 @@ class ServiceController extends AbstractController
             'fichajes' => $fichajesByVolunteer,
         ]);
     }
+
+    /**
+     * API endpoint to suggest the next sequential numeration for a service.
+     */
+    #[Route('/api/service/next-numeration', name: 'api_service_next_numeration', methods: ['GET'])]
+    public function getNextNumeration(Request $request, ServiceRepository $serviceRepository, EntityManagerInterface $entityManager): JsonResponse
+    {
+        if (!$this->isGranted('ROLE_USER')) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $typeId = $request->query->get('type_id');
+        $dateStr = $request->query->get('date');
+
+        $startDate = $dateStr ? new \DateTime($dateStr) : null;
+        $type = $typeId ? $entityManager->getRepository(\App\Entity\ServiceType::class)->find($typeId) : null;
+
+        $suggestedId = $serviceRepository->generateNextNumeration($type, $startDate);
+
+        return new JsonResponse([
+            'suggestedId' => $suggestedId
+        ]);
+    }
 }

--- a/src/EntityListener/ServiceEntityListener.php
+++ b/src/EntityListener/ServiceEntityListener.php
@@ -18,30 +18,10 @@ class ServiceEntityListener
     public function prePersist(Service $service, PrePersistEventArgs $event): void
     {
         if (!$service->getNumeration()) {
-            $year = $service->getStartDate() ? (int)$service->getStartDate()->format('Y') : (int)date('Y');
-
-            // 1. Annual counter: EXP-[YEAR]-[ANUAL_NUMBER]
-            $anualNumber = $this->serviceRepository->getNextSequentialNumber($year);
-            $expPart = sprintf('EXP-%d-%03d', $year, $anualNumber);
-
-            // 2. Class counter: [TYPE]-[CAT]-[SUB]-[CLASS_NUMBER]
-            $type = $service->getType();
-            $cat = $service->getCategory();
-            $sub = $service->getSubcategory();
-
-            $typeCode = $type ? ($type->getCode() ?: strtoupper(substr($type->getName(), 0, 3))) : 'XXX';
-            $catCode = $cat ? ($cat->getCode() ?: strtoupper(substr($cat->getName(), 0, 3))) : 'XXX';
-            $subCode = $sub ? ($sub->getCode() ?: strtoupper(substr($sub->getName(), 0, 3))) : 'XXX';
-
-            $classNumber = $this->serviceRepository->getClassSequentialNumber($type, $cat, $sub);
-            $classPart = sprintf('%s-%s-%s-%03d', $typeCode, $catCode, $subCode, $classNumber);
-
-            // 3. Global counter: REG-[TOTAL_NUMBER]
-            $totalNumber = $this->serviceRepository->getGlobalTotalCount() + 1;
-            $regPart = sprintf('REG-%03d', $totalNumber);
-
-            // Final: EXP-2025-001 | PRE-DEP-FUT-001 | REG-001
-            $generatedId = sprintf('%s | %s | %s', $expPart, $classPart, $regPart);
+            $generatedId = $this->serviceRepository->generateNextNumeration(
+                $service->getType(),
+                $service->getStartDate()
+            );
 
             $service->setNumeration($generatedId);
         }

--- a/src/Repository/ServiceRepository.php
+++ b/src/Repository/ServiceRepository.php
@@ -249,6 +249,47 @@ class ServiceRepository extends ServiceEntityRepository
     }
 
     /**
+     * Gets the next sequential number for services of a specific type in a given year.
+     */
+    public function getNextSequentialNumberByTypeAndYear($type, int $year): int
+    {
+        $startOfYear = new \DateTime("$year-01-01 00:00:00");
+        $endOfYear = new \DateTime("$year-12-31 23:59:59");
+
+        $qb = $this->createQueryBuilder('s')
+            ->select('count(s.id)')
+            ->where('s.startDate BETWEEN :start AND :end')
+            ->setParameter('start', $startOfYear)
+            ->setParameter('end', $endOfYear);
+
+        if ($type) {
+            $qb->andWhere('s.type = :type')
+               ->setParameter('type', $type);
+        } else {
+            $qb->andWhere('s.type IS NULL');
+        }
+
+        return (int) $qb->getQuery()->getSingleScalarResult() + 1;
+    }
+
+    /**
+     * Generates the next suggested numeration ID for a service.
+     */
+    public function generateNextNumeration($type, ?\DateTimeInterface $startDate): string
+    {
+        $year = $startDate ? (int)$startDate->format('Y') : (int)date('Y');
+
+        $typeCode = 'SERV';
+        if ($type instanceof \App\Entity\ServiceType) {
+            $typeCode = $type->getCode() ?: mb_strtoupper(mb_substr($type->getName(), 0, 3));
+        }
+
+        $sequentialNumber = $this->getNextSequentialNumberByTypeAndYear($type, $year);
+
+        return sprintf('%s-%d/%03d', $typeCode, $year, $sequentialNumber);
+    }
+
+    /**
      * Gets the absolute total count of services in the system.
      */
     public function getGlobalTotalCount(): int


### PR DESCRIPTION
- Unified service ID format to [TYPE]-[YEAR]/[NUMBER] (e.g., PRE-2025/001).
- Implemented real-time ID suggestion in the service form via a new API endpoint.
- Centralized numeration logic in ServiceRepository for maintainability.
- Added access control to the numeration suggestion API.
- Ensured multibyte safety for type code generation.