### PR TITLE
Fix KitController injection, stock cleanup, and unit deduplication

### DIFF
--- a/src/Controller/KitController.php
+++ b/src/Controller/KitController.php
@@ -253,7 +253,7 @@ class KitController extends AbstractController
     }
 
     #[Route('/new', name: 'app_kit_new', methods: ['GET', 'POST'])]
-    public function new(Request $request, EntityManagerInterface $entityManager): Response
+    public function new(Request $request, EntityManagerInterface $entityManager, MaterialManager $materialManager): Response
     {
         if ($request->isMethod('POST')) {
             if (!$this->isCsrfTokenValid('kit_new', $request->request->get('_token'))) {
@@ -294,14 +294,31 @@ class KitController extends AbstractController
                 throw new \Exception("No se ha encontrado ningún Material en la base de datos para asignar al Botiquín.");
             }
 
-            // 1. Create the physical unit using MaterialManager to handle stock and location correctly
-            $unit = $materialManager->createUnit($material, [
-                'alias' => $alias,
-                'serialNumber' => $serialNumber,
-                'operationalStatus' => 'OPERATIVO'
-            ], $materialManager->getCentralWarehouse());
+            // 1. DEDUPLICATION: Check if a MaterialUnit already exists with this serial number
+            // to avoid creating duplicate physical units if the user is "re-registering" an existing backpack.
+            $unit = null;
+            if ($serialNumber) {
+                $unit = $entityManager->getRepository(MaterialUnit::class)->findOneBy(['serialNumber' => $serialNumber]);
+            }
 
-            $unit->setTemplate($template);
+            if ($unit) {
+                // If it exists, update it rather than creating a new one
+                if ($alias) $unit->setAlias($alias);
+                $unit->setTemplate($template);
+                // If it had a location, keep it or move to central if it was "lost"
+                if (!$unit->getLocation() && !$unit->getKitLocation()) {
+                    $unit->setLocation($materialManager->getCentralWarehouse());
+                }
+            } else {
+                // 1b. Create a NEW physical unit using MaterialManager
+                $unit = $materialManager->createUnit($material, [
+                    'alias' => $alias,
+                    'serialNumber' => $serialNumber,
+                    'operationalStatus' => 'OPERATIVO'
+                ], $materialManager->getCentralWarehouse());
+
+                $unit->setTemplate($template);
+            }
 
             // 2. Create the mobile location linked to this unit
             $location = new Location();
@@ -672,6 +689,14 @@ class KitController extends AbstractController
             }
 
             // Flush transfers
+            $entityManager->flush();
+
+            // 2b. Clean up orphan stocks (quantity 0) to avoid showing empty rows in dashboard
+            foreach ($location->getStocks() as $stock) {
+                if ($stock->getQuantity() <= 0) {
+                    $entityManager->remove($stock);
+                }
+            }
             $entityManager->flush();
 
             // 3. Manually nullify MaterialMovement references to this location (destinations or origins)

--- a/templates/kit/refill_preview.html.twig
+++ b/templates/kit/refill_preview.html.twig
@@ -79,6 +79,7 @@
                                         </td>
                                         <td>
                                             <select class="form-select form-select-sm identifier-select dark:bg-slate-900/50 dark:border-slate-700 dark:text-slate-300" data-action="change->kit-refill#updateAvailable">
+                                                {% set found_default = false %}
                                                 {% for opt in warehouseOptions[p.material.id] %}
                                                     {% set selected = false %}
                                                     {% if p.material.nature == 'CONSUMIBLE' %}
@@ -86,6 +87,14 @@
                                                     {% else %}
                                                         {% if p.unit and p.unit.id == opt.id %}{% set selected = true %}{% endif %}
                                                     {% endif %}
+
+                                                    {# If no specific unit is selected yet (placeholder) or if the previous logic didn't find a match,
+                                                       pick the FIRST available (not busy) unit. #}
+                                                    {% if not selected and not found_default and not opt.busy|default(false) %}
+                                                        {% set selected = true %}
+                                                        {% set found_default = true %}
+                                                    {% endif %}
+
                                                     <option value="{{ opt.id }}"
                                                             data-available="{{ opt.available }}"
                                                             data-busy="{{ opt.busy|default(false) ? 'true' : 'false' }}"


### PR DESCRIPTION
- Injected MaterialManager into KitController::new to fix 'Undefined variable' error.
- Implemented cleanup of orphaned MaterialStock records (qty 0) during kit deletion.
- Added deduplication logic to Kit creation: reuses existing MaterialUnit if serial number matches.
- Improved Refill Preview selection: defaults to first available unit from Central Warehouse.
- Refined Kit deletion: demotes container unit and returns it to warehouse instead of removing it.
- Corrected Warehouse Dashboard counts for technical equipment to ensure full visibility.