### PR TITLE
fix: consolidate material movement records on transfer

### DIFF
--- a/src/Service/MaterialManager.php
+++ b/src/Service/MaterialManager.php
@@ -251,16 +251,17 @@ class MaterialManager
             if ($currentLocation) {
                 // Withdrawal from origin
                 $this->updateStockWithBatch($material, $currentLocation, -$quantity, null, $size);
-                $this->recordMovement($material, $quantity, $transferReason, $currentLocation, $destination, $responsible, $size, $batch, $now, true, $unit);
 
                 if ($destination) {
                     // Entry to destination
                     $unit->setLocation($destination);
                     $this->updateStockWithBatch($material, $destination, $quantity, null, $size);
-                    $this->recordMovement($material, $quantity, $transferReason, $currentLocation, $destination, $responsible, $size, $batch, $now, false, $unit);
                 } else {
                     $unit->setLocation(null);
                 }
+
+                // Single record for transfer or exit
+                $this->recordMovement($material, $quantity, $transferReason, $currentLocation, $destination, $responsible, $size, $batch, $now, $destination === null, $unit);
             } else {
                 // It's a new entry (Registration)
                 if ($destination) {
@@ -288,12 +289,13 @@ class MaterialManager
                 if ($stock && $stock->getQuantity() > 0) {
                     $toSubtract = min($remainingToSubtract, $stock->getQuantity());
                     $this->updateStockWithBatch($material, $origin, -$toSubtract, $b, $size);
-                    $this->recordMovement($material, $toSubtract, $transferReason, $origin, $destination, $responsible, $size, $b, $now, true);
 
                     if ($destination) {
                         $this->updateStockWithBatch($material, $destination, $toSubtract, $b, $size);
-                        $this->recordMovement($material, $toSubtract, $transferReason, $origin, $destination, $responsible, $size, $b, $now, false);
                     }
+
+                    // Single record for the specific batch transfer/exit
+                    $this->recordMovement($material, $toSubtract, $transferReason, $origin, $destination, $responsible, $size, $b, $now, $destination === null);
 
                     $remainingToSubtract -= $toSubtract;
                     if ($remainingToSubtract <= 0) break;
@@ -302,24 +304,24 @@ class MaterialManager
 
             if ($remainingToSubtract > 0) {
                 $this->updateStockWithBatch($material, $origin, -$remainingToSubtract, null, $size);
-                $this->recordMovement($material, $remainingToSubtract, $transferReason, $origin, $destination, $responsible, $size, null, $now, true);
                 if ($destination) {
                     $this->updateStockWithBatch($material, $destination, $remainingToSubtract, null, $size);
-                    $this->recordMovement($material, $remainingToSubtract, $transferReason, $origin, $destination, $responsible, $size, null, $now, false);
                 }
+                // Single record for the remaining (no batch) transfer/exit
+                $this->recordMovement($material, $remainingToSubtract, $transferReason, $origin, $destination, $responsible, $size, null, $now, $destination === null);
             }
         } else {
             // Explicit batch or entry from null origin (Registration/Initial Entry)
             if ($origin) {
                 $this->updateStockWithBatch($material, $origin, -$quantity, $batch, $size);
-                $this->recordMovement($material, $quantity, $transferReason, $origin, $destination, $responsible, $size, $batch, $now, true);
             }
 
             if ($destination) {
                 $this->updateStockWithBatch($material, $destination, $quantity, $batch, $size);
-                $finalReason = $origin ? $transferReason : $entryReason;
-                $this->recordMovement($material, $quantity, $finalReason, $origin, $destination, $responsible, $size, $batch, $now, false);
             }
+
+            $finalReason = $origin ? $transferReason : $entryReason;
+            $this->recordMovement($material, $quantity, $finalReason, $origin, $destination, $responsible, $size, $batch, $now, $destination === null && $origin !== null);
         }
 
     }

--- a/tests/Service/MaterialManagerTest.php
+++ b/tests/Service/MaterialManagerTest.php
@@ -246,6 +246,16 @@ class MaterialManagerTest extends TestCase
         $this->stockRepository->method('findOneBy')
             ->willReturn(null);
 
+        // Expect exactly one persist for MaterialMovement
+        $movementPersists = 0;
+        $this->entityManager->expects($this->any())
+            ->method('persist')
+            ->willReturnCallback(function($entity) use (&$movementPersists) {
+                if ($entity instanceof MaterialMovement) {
+                    $movementPersists++;
+                }
+            });
+
         $this->materialManager->transfer(
             $material,
             $origin,
@@ -257,6 +267,45 @@ class MaterialManagerTest extends TestCase
 
         // Global stock should remain unchanged
         $this->assertEquals(10, $material->getStock());
+        $this->assertEquals(1, $movementPersists, "Should only persist one movement record for transfer");
+    }
+
+    public function testTransferConsolidation(): void
+    {
+        $this->mockMovementQueryBuilder();
+        $material = new Material();
+        $material->setNature(Material::NATURE_CONSUMABLE);
+
+        $origin = new \App\Entity\Location();
+        $origin->setName('Origin');
+        $destination = new \App\Entity\Location();
+        $destination->setName('Destination');
+
+        $this->stockRepository->method('findOneBy')->willReturn(null);
+
+        $recordedMovement = null;
+        $this->entityManager->expects($this->any())
+            ->method('persist')
+            ->willReturnCallback(function($entity) use (&$recordedMovement) {
+                if ($entity instanceof MaterialMovement) {
+                    $recordedMovement = $entity;
+                }
+            });
+
+        $this->materialManager->transfer(
+            $material,
+            $origin,
+            $destination,
+            5,
+            'Custom Reason',
+            null
+        );
+
+        $this->assertNotNull($recordedMovement);
+        $this->assertEquals(5, $recordedMovement->getQuantity());
+        $this->assertEquals($origin, $recordedMovement->getOrigin());
+        $this->assertEquals($destination, $recordedMovement->getDestination());
+        $this->assertStringContainsString('Traspaso: Origin -> Destination', $recordedMovement->getReason());
     }
 
     public function testIdempotencyCacheCatchSameRequestDuplicates(): void


### PR DESCRIPTION
Previously, stock transfers recorded two separate entries (one positive and one negative) in the movement history. This change unifies transfers into a single positive record that includes both origin and destination locations, improving history legibility and data consistency.

- Updated MaterialManager::transfer to record only one MaterialMovement for transfers.
- Adjusted tests to verify single record persistence.
- Maintained separate records for pure withdrawals and entries.