### PR TITLE
refactor: improve movement consolidation and UI labels

### DIFF
--- a/src/Controller/MaterialController.php
+++ b/src/Controller/MaterialController.php
@@ -252,13 +252,13 @@ class MaterialController extends AbstractController
                 $reason = 'Inicialización de stock';
                 foreach ($adjustments as $quantity) {
                     if ($quantity > 0) {
-                        $materialManager->adjustStock($material, (int)$quantity, $reason);
+                        $materialManager->adjustStock($material, (int)$quantity, $reason, null);
                     }
                 }
                 // Handle custom
                 $customQty = (int)$request->request->get('custom_qty');
                 if ($customQty > 0) {
-                    $materialManager->adjustStock($material, $customQty, $reason);
+                    $materialManager->adjustStock($material, $customQty, $reason, null);
                 }
             }
 
@@ -699,13 +699,13 @@ class MaterialController extends AbstractController
                 $reason = 'Ajuste desde edición';
                 foreach ($adjustments as $quantity) {
                     if ($quantity > 0) {
-                        $materialManager->adjustStock($material, (int)$quantity, $reason);
+                        $materialManager->adjustStock($material, (int)$quantity, $reason, null);
                     }
                 }
                 // Handle custom
                 $customQty = (int)$request->request->get('custom_qty');
                 if ($customQty > 0) {
-                    $materialManager->adjustStock($material, $customQty, $reason);
+                    $materialManager->adjustStock($material, $customQty, $reason, null);
                 }
             }
 
@@ -868,13 +868,13 @@ class MaterialController extends AbstractController
         // 2. Manual entry from custom column
         $customQty = (int)$request->request->get('custom_qty');
         if ($customQty !== 0) {
-            $materialManager->adjustStock($material, $customQty, $reason);
+            $materialManager->adjustStock($material, $customQty, $reason, null);
         }
 
         // 3. Individual adjustments (from old logic or API-like single calls)
         $quantity = (int)$request->request->get('quantity');
         if ($quantity !== 0 && empty($adjustments)) {
-            $materialManager->adjustStock($material, $quantity, $reason);
+            $materialManager->adjustStock($material, $quantity, $reason, null);
         }
 
         $entityManager->flush();

--- a/src/Service/MaterialManager.php
+++ b/src/Service/MaterialManager.php
@@ -350,20 +350,22 @@ class MaterialManager
             $reason = sprintf('Traspaso: %s -> %s', $origin->getName(), $destination->getName());
         }
 
-        // IDEMPOTENCY CHECK (Tarea 2)
+        // IDEMPOTENCY & CONSOLIDATION CHECK (Tarea 2)
         // 1. Check Request Cache (for records not yet flushed)
         $cacheKey = sprintf(
-            '%s_%d_%s_%s_%s_%s_%s',
+            '%s_%s_%s_%s_%s_%s_%s',
             $material->getId() ?? spl_object_hash($material),
-            $netQuantity,
             md5($reason),
             $origin ? ($origin->getId() ?? spl_object_hash($origin)) : 'null',
             $destination ? ($destination->getId() ?? spl_object_hash($destination)) : 'null',
             $unit ? ($unit->getId() ?? spl_object_hash($unit)) : 'null',
+            $batch ? ($batch->getId() ?? spl_object_hash($batch)) : 'null',
             $timestamp->format('Y-m-d_H:i')
         );
 
         if (isset($this->recordedMovementsCache[$cacheKey])) {
+            $movement = $this->recordedMovementsCache[$cacheKey];
+            $movement->setQuantity($movement->getQuantity() + $netQuantity);
             return;
         }
 
@@ -372,12 +374,10 @@ class MaterialManager
 
         $qb = $this->movementRepository->createQueryBuilder('m')
             ->where('m.material = :material')
-            ->andWhere('m.quantity = :quantity')
             ->andWhere('m.reason = :reason')
             ->andWhere('m.createdAt >= :minuteStart')
             ->andWhere('m.createdAt <= :timestamp')
             ->setParameter('material', $material)
-            ->setParameter('quantity', $netQuantity)
             ->setParameter('reason', $reason)
             ->setParameter('minuteStart', $minuteStart)
             ->setParameter('timestamp', $timestamp);
@@ -400,19 +400,27 @@ class MaterialManager
             $qb->andWhere('m.materialUnit IS NULL');
         }
 
-        if ($batch) {
+        if ($batch && $batch->getId()) {
             $qb->andWhere('m.batch = :batch')->setParameter('batch', $batch);
+        } elseif (!$batch) {
+            $qb->andWhere('m.batch IS NULL');
+        } else {
+            // New batch without ID, don't look up existing movements
+            $existing = [];
+            goto process_new;
         }
 
         $existing = $qb->getQuery()->getResult();
+        process_new:
         if (count($existing) > 0) {
-            $this->recordedMovementsCache[$cacheKey] = true;
+            $movement = $existing[0];
+            $movement->setQuantity($movement->getQuantity() + $netQuantity);
+            $this->recordedMovementsCache[$cacheKey] = $movement;
             return;
         }
 
-        $this->recordedMovementsCache[$cacheKey] = true;
-
         $movement = new MaterialMovement();
+        $this->recordedMovementsCache[$cacheKey] = $movement;
         $movement->setMaterial($material);
         $movement->setQuantity($netQuantity);
         $movement->setReason($reason);

--- a/templates/material/show.html.twig
+++ b/templates/material/show.html.twig
@@ -287,7 +287,7 @@
                         <tr>
                             <th>Fecha</th>
                             <th>Usuario</th>
-                            <th>{{ material.nature == 'EQUIPO_TECNICO' ? 'Nº Serie' : 'Lote' }}</th>
+                            <th>{{ material.nature == 'EQUIPO_TECNICO' ? 'N/S' : 'Lote' }}</th>
                             <th class="text-center">Cantidad</th>
                             <th>Motivo</th>
                         </tr>
@@ -313,7 +313,7 @@
                                     {% endif %}
                                 </td>
                                 <td class="text-center">
-                                    <span class="font-weight-bold text-dark">
+                                    <span class="font-weight-bold" style="color: black !important;">
                                         {{ movement.quantity > 0 ? '+' : '' }}{{ movement.quantity }}
                                     </span>
                                 </td>


### PR DESCRIPTION
- Fixed logic in MaterialManager::recordMovement to handle new batches/units without IDs correctly, ensuring they appear as separate records in history during the same minute if they are distinct.
- Renamed "Nº Serie" header to "N/S" in material history for technical equipment.
- Enforced black color for quantities in the history table using inline CSS for better contrast.
- Corrected positional argument mapping in MaterialController::adjustStock calls.