### PR TITLE
fix(kit): resolve 500 error in refill preview and prevent UI duplicates

### DIFF
--- a/src/Controller/KitController.php
+++ b/src/Controller/KitController.php
@@ -473,6 +473,12 @@ class KitController extends AbstractController
         // 1. Map existing stock in the kit (to avoid "disappearance" on reload/back)
         foreach ($kitLocation->getStocks() as $stock) {
             if ($stock->getQuantity() <= 0) continue;
+
+            // Skip technical equipment in the stock loop as they are handled in the units loop below
+            if ($stock->getMaterial()->getNature() === Material::NATURE_TECHNICAL) {
+                continue;
+            }
+
             $currentContents[] = [
                 'material' => $stock->getMaterial(),
                 'quantity' => $stock->getQuantity(),

--- a/templates/kit/refill_preview.html.twig
+++ b/templates/kit/refill_preview.html.twig
@@ -62,7 +62,7 @@
                                                 {% if item.material.nature == 'CONSUMIBLE' %}
                                                     {{ item.batch ? 'Lote: ' ~ item.batch.batchNumber : 'Sin Lote' }}
                                                 {% else %}
-                                                    {{ item.unit.serialNumber ?: 'S/N' }}
+                                                    {{ (item.unit and item.unit.serialNumber) ? item.unit.serialNumber : 'S/N' }}
                                                 {% endif %}
                                             </span>
                                         </td>
@@ -80,7 +80,7 @@
                                         style="{{ p.placeholder|default(false) ? 'border-left: 3px solid #f87171;' : '' }}">
                                         <td class="ps-4">
                                             <div class="font-bold text-slate-800 dark:text-slate-200">
-                                                {% if p.unit and p.unit.alias %}
+                                                {% if p.unit is defined and p.unit and p.unit.alias %}
                                                     {{ p.unit.alias }} <span class="text-slate-400 text-xxs font-normal">({{ p.material.name }})</span>
                                                 {% else %}
                                                     {{ p.material.name }}


### PR DESCRIPTION
- Added null checks for MaterialUnit in refill_preview.html.twig to prevent 500 error when serialNumber is missing.
- Updated KitController::refillPreview to skip technical equipment in the stock loop (as they are handled in the units loop), preventing duplicate rows for the same item.