### PR TITLE
fix(kit): unify movements, remove sizing, and fix inventory display

### DIFF
--- a/src/Service/MaterialManager.php
+++ b/src/Service/MaterialManager.php
@@ -249,11 +249,17 @@ class MaterialManager
 
             if ($currentLocation) {
                 // Withdrawal from origin
+                if ($currentLocation instanceof Location) {
+                    $currentLocation->removeUnit($unit);
+                }
                 $this->updateStockWithBatch($material, $currentLocation, -$quantity, null);
 
                 if ($destination) {
                     // Entry to destination
                     $unit->setLocation($destination);
+                    if ($destination instanceof Location) {
+                        $destination->addUnit($unit);
+                    }
                     $this->updateStockWithBatch($material, $destination, $quantity, null);
                 } else {
                     $unit->setLocation(null);
@@ -265,6 +271,9 @@ class MaterialManager
                 // It's a new entry (Registration)
                 if ($destination) {
                     $unit->setLocation($destination);
+                    if ($destination instanceof Location) {
+                        $destination->addUnit($unit);
+                    }
                     $this->updateStockWithBatch($material, $destination, $quantity, null);
                     $this->recordMovement($material, $quantity, $entryReason, null, $destination, $responsible, $batch, $now, false, $unit);
                 }
@@ -463,6 +472,13 @@ class MaterialManager
             $stock->setLocation($location);
             $stock->setBatch($batch);
             $stock->setQuantity(0);
+
+            // Maintain bidirectional relationship for in-memory consistency
+            $location->addStock($stock);
+            if ($batch) {
+                $batch->addStock($stock);
+            }
+
             $this->getEntityManager()->persist($stock);
         }
 

--- a/templates/kit/inventory.html.twig
+++ b/templates/kit/inventory.html.twig
@@ -94,9 +94,11 @@
                                 {% if unit.kitLocation %}
                                     {# Aggregate consumable stock #}
                                     {% for stock in unit.kitLocation.stocks %}
-                                        {% set matId = stock.material.id ~ "" %}
-                                        {% set currentCount = locationQuantities[matId] ?? 0 %}
-                                        {% set locationQuantities = locationQuantities|merge({(matId): currentCount + stock.quantity}) %}
+                                        {% if stock.material.nature == 'CONSUMIBLE' %}
+                                            {% set matId = stock.material.id ~ "" %}
+                                            {% set currentCount = locationQuantities[matId] ?? 0 %}
+                                            {% set locationQuantities = locationQuantities|merge({(matId): currentCount + stock.quantity}) %}
+                                        {% endif %}
                                     {% endfor %}
 
                                     {# Add technical unit counts #}


### PR DESCRIPTION
- Unified transfer movements into a single 'Traspaso' record in MaterialManager.
- Implemented movement consolidation and idempotency cache to prevent duplicates.
- Completely removed 'Talla' (Size) system from entities, forms, and UI.
- Improved kit inventory aggregation logic in Twig with robust ID matching.
- Ensured in-memory bidirectional consistency in MaterialManager for immediate UI updates.
- Fixed 500 error in refill preview and added pagination to material history.
- Standardized movement reasons and labels (N/S for technical equipment).