### PR TITLE
fix: resolve stock duplication and dynamic transfer origin

### DIFF
--- a/assets/controllers/kit-refill_controller.js
+++ b/assets/controllers/kit-refill_controller.js
@@ -218,6 +218,7 @@ export default class extends Controller {
             const proposal = {
                 material_id: materialId,
                 origin_id: identifierSelect.options[identifierSelect.selectedIndex].dataset.locationId || this.originIdValue,
+                stock_id: nature === 'CONSUMIBLE' ? (identifierSelect.options[identifierSelect.selectedIndex].dataset.stockId || null) : null,
                 quantity: quantity,
                 batch_id: nature === 'CONSUMIBLE' ? (identifierSelect.value === 'NO_BATCH' ? null : identifierSelect.value) : null,
                 unit_id: nature === 'EQUIPO_TECNICO' ? identifierSelect.value : null

--- a/migrations/Version20260420000000.php
+++ b/migrations/Version20260420000000.php
@@ -19,13 +19,35 @@ final class Version20260420000000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // First, consolidate any existing duplicates if they exist
-        // Note: This is a complex operation in SQL that varies by DB.
-        // For simplicity in this migration, we'll try to add the index and it might fail if there are duplicates.
-        // But since the user reported the issue, they likely have duplicates.
+        // Consolidate any existing duplicates before adding the index
+        // We sum quantities of duplicates into one record and delete the others.
+        $this->addSql("
+            CREATE TEMPORARY TABLE stock_duplicates AS
+            SELECT MIN(id) as keep_id, material_id, location_id, batch_id, SUM(quantity) as total_quantity
+            FROM material_stock
+            GROUP BY material_id, location_id, batch_id
+            HAVING COUNT(*) > 1
+        ");
 
-        // Manual consolidation if possible:
-        // (This might be better done in a separate script or just let the index fail if duplicates exist)
+        $this->addSql("
+            UPDATE material_stock ms
+            JOIN stock_duplicates sd ON ms.id = sd.keep_id
+            SET ms.quantity = sd.total_quantity
+        ");
+
+        $this->addSql("
+            DELETE ms FROM material_stock ms
+            JOIN (
+                SELECT ms2.id
+                FROM material_stock ms2
+                JOIN stock_duplicates sd ON ms2.material_id = sd.material_id
+                    AND ms2.location_id <=> sd.location_id
+                    AND ms2.batch_id <=> sd.batch_id
+                WHERE ms2.id != sd.keep_id
+            ) to_delete ON ms.id = to_delete.id
+        ");
+
+        $this->addSql("DROP TEMPORARY TABLE stock_duplicates");
 
         $this->addSql('CREATE UNIQUE INDEX UNIQ_MATERIAL_STOCK_ML_BATCH ON material_stock (material_id, location_id, batch_id)');
     }

--- a/src/Controller/KitController.php
+++ b/src/Controller/KitController.php
@@ -568,11 +568,6 @@ class KitController extends AbstractController
         // We also exclude any other MaterialUnit that is already assigned to a Location of type KIT (busy).
         // Except if we are doing manualOnly, in which case we show everything but mark busy.
 
-        // Skip the kit container itself by ID (important if it's the same material type)
-        if ($unit->getId() && $material->getId() === $unit->getMaterial()->getId()) {
-            // Further check to see if we are trying to propose the container unit itself
-            // This is handled in the unit loop below, but we can skip the whole material if it's ONLY for the container
-        }
 
         // Calculate current stock in the kit correctly
         $currentQty = 0;
@@ -628,6 +623,7 @@ class KitController extends AbstractController
 
                 $options[] = [
                     'id' => $stock->getBatch() ? $stock->getBatch()->getId() : 'NO_BATCH',
+                    'stock_id' => $stock->getId(),
                     'label' => $stock->getBatch() ? 'Lote: ' . $stock->getBatch()->getBatchNumber() . ' (Exp: ' . ($stock->getBatch()->getExpirationDate() ? $stock->getBatch()->getExpirationDate()->format('d/m/Y') : 'N/A') . ')' : 'Sin Lote',
                     'available' => $stock->getQuantity(),
                     'busy' => $isBusy,
@@ -910,12 +906,18 @@ class KitController extends AbstractController
                     $material = $entityManager->getRepository(Material::class)->find($p['material_id']);
                     $batch = !empty($p['batch_id']) ? $entityManager->getRepository(\App\Entity\MaterialBatch::class)->find($p['batch_id']) : null;
                     $unitToMove = !empty($p['unit_id']) ? $entityManager->getRepository(MaterialUnit::class)->find($p['unit_id']) : null;
+                    $stockToMove = !empty($p['stock_id']) ? $entityManager->getRepository(MaterialStock::class)->find($p['stock_id']) : null;
 
                     $originId = $p['origin_id'] ?? null;
                     $origin = $originId ? $entityManager->getRepository(Location::class)->find($originId) : null;
 
                     if ($unitToMove && $unitToMove->getLocation()) {
                         $origin = $unitToMove->getLocation();
+                    }
+
+                    if ($stockToMove && $stockToMove->getLocation()) {
+                        $origin = $stockToMove->getLocation();
+                        $batch = $stockToMove->getBatch(); // Ensure correct batch from stock
                     }
 
                     if (!$origin) {

--- a/templates/kit/refill_preview.html.twig
+++ b/templates/kit/refill_preview.html.twig
@@ -102,6 +102,7 @@
 
                                                 {% for opt in warehouseOptions[p.material.id] %}
                                                     <option value="{{ opt.id }}"
+                                                            data-stock-id="{{ opt.stock_id|default('') }}"
                                                             data-available="{{ opt.available }}"
                                                             data-busy="{{ opt.busy|default(false) ? 'true' : 'false' }}"
                                                             data-location-name="{{ opt.locationName|default('') }}"


### PR DESCRIPTION
- Implement dynamic origin tracking for transfers using stock_id.
- Update KitController and frontend to pass specific stock IDs during refill/creation.
- Improve Dashboard to separate 'Botiquines' from general 'Equipos Técnicos'.
- Fix duplication in MaterialManager with stocksCache and collection sync.
- Add migration Version20260420000000 to merge duplicates and add UNIQUE constraint.