### PR TITLE
fix: complete inventory overhaul with strict medical stock defaults

### DIFF
--- a/src/Controller/KitController.php
+++ b/src/Controller/KitController.php
@@ -319,7 +319,7 @@ class KitController extends AbstractController
     #[Route('/new/preview', name: 'app_kit_new_preview', methods: ['GET'])]
     public function newPreview(Request $request, EntityManagerInterface $entityManager, MaterialManager $materialManager): Response
     {
-        $centralWarehouse = $materialManager->getCentralWarehouse();
+        $centralWarehouse = $materialManager->getPharmacyWarehouse(); // Force Pharmacy as primary source for kits
         $session = $request->getSession();
         $draft = $session->get('draft_kit');
 
@@ -457,7 +457,7 @@ class KitController extends AbstractController
     #[Route('/{id}/refill/preview', name: 'app_kit_refill_preview', methods: ['GET'])]
     public function refillPreview(MaterialUnit $unit, MaterialManager $materialManager, EntityManagerInterface $entityManager): Response
     {
-        $centralWarehouse = $materialManager->getCentralWarehouse();
+        $centralWarehouse = $materialManager->getPharmacyWarehouse(); // Force Pharmacy as primary source for kits
         $template = $unit->getTemplate();
         if (!$template) {
             throw $this->createNotFoundException('Este botiquín no tiene una plantilla asignada.');
@@ -919,7 +919,7 @@ class KitController extends AbstractController
                     }
 
                     if (!$origin) {
-                        $origin = $materialManager->getCentralWarehouse();
+                        $origin = $materialManager->getPharmacyWarehouse();
                     }
 
                     $materialManager->transfer(

--- a/src/Controller/MaterialController.php
+++ b/src/Controller/MaterialController.php
@@ -825,7 +825,16 @@ class MaterialController extends AbstractController
     public function transfer(Request $request, Material $material, MaterialManager $materialManager, EntityManagerInterface $entityManager): Response
     {
         $originId = $request->query->get('origin_id');
-        $defaultOrigin = $originId ? $entityManager->getRepository(\App\Entity\Location::class)->find($originId) : null;
+        $defaultOrigin = null;
+
+        if ($originId) {
+            $defaultOrigin = $entityManager->getRepository(\App\Entity\Location::class)->find($originId);
+        }
+
+        // Fallback to material's default warehouse if no specific origin was requested
+        if (!$defaultOrigin) {
+            $defaultOrigin = $materialManager->getDefaultLocation($material);
+        }
 
         $form = $this->createForm(MaterialTransferType::class, ['origin' => $defaultOrigin], ['material' => $material]);
         $form->handleRequest($request);

--- a/src/Service/MaterialManager.php
+++ b/src/Service/MaterialManager.php
@@ -674,28 +674,6 @@ class MaterialManager
     }
 
     /**
-     * Returns the Pharmacy Warehouse location (Almacén Farmacia).
-     */
-    public function getPharmacyWarehouse(): Location
-    {
-        if (!$this->getEntityManager()->isOpen()) {
-            throw new \RuntimeException("EntityManager is closed. Cannot retrieve Pharmacy Warehouse.");
-        }
-
-        $warehouse = $this->getEntityManager()->getRepository(Location::class)->findOneBy(['name' => 'Almacén Farmacia']);
-
-        if (!$warehouse) {
-            $warehouse = new Location();
-            $warehouse->setName('Almacén Farmacia');
-            $warehouse->setType(Location::TYPE_WAREHOUSE);
-            $this->getEntityManager()->persist($warehouse);
-            $this->getEntityManager()->flush();
-        }
-
-        return $warehouse;
-    }
-
-    /**
      * Returns the Central Warehouse location.
      */
     public function getCentralWarehouse(): Location
@@ -707,11 +685,11 @@ class MaterialManager
         $warehouse = $this->getEntityManager()->getRepository(Location::class)->findOneBy(['name' => 'Almacén Central']);
 
         if (!$warehouse) {
-            // Priority 1: Check by name if findOneBy type returned wrong one
-            $warehouse = $this->getEntityManager()->getRepository(Location::class)->findOneBy(['name' => 'Almacén Central']);
-            
+            // Priority 1: Check for Pharmacy as a better default for this system
+            $warehouse = $this->getEntityManager()->getRepository(Location::class)->findOneBy(['name' => 'Almacén Farmacia']);
+
             if (!$warehouse) {
-                // Priority 2: Check by type alone as fallback
+                // Priority 2: Any warehouse
                 $warehouse = $this->getEntityManager()->getRepository(Location::class)->findOneBy(['type' => Location::TYPE_WAREHOUSE]);
             }
 


### PR DESCRIPTION
- Correct bi-directional mapping between MaterialUnit and Location (ManyToOne/OneToMany).
- Resolve undefined method error in KitController by using addMaterialUnit.
- Force Pharmacy Warehouse as default origin for kit refills/creation.
- Implement intelligent origin pre-selection in MaterialController::transfer.
- Ensure non-negative stock and strict batch tracking in MaterialManager.
- Implement Dashboard 'BOTIQUINES' column and accurate container counting.
- Prevent kit container from appearing in its own refill proposals.
- Add migration to consolidate duplicates and enforce UNIQUE constraints.