### PR TITLE
Fix explicit stock resolution in material transfers

### DIFF
--- a/assets/controllers/kit-refill_controller.js
+++ b/assets/controllers/kit-refill_controller.js
@@ -214,9 +214,10 @@ export default class extends Controller {
             const identifierSelect = row.querySelector('.identifier-select');
             const quantity = parseInt(row.querySelector('.quantity-input').value);
 
-            if (!materialId || !identifierSelect || !identifierSelect.value) return;
+            if (!materialId || !identifierSelect || !identifierSelect.value || identifierSelect.value === 'NONE') return;
 
             const selectedOption = identifierSelect.options[identifierSelect.selectedIndex];
+            if (!selectedOption || !selectedOption.value) return;
             const isBusy = selectedOption.dataset.busy === 'true';
 
             if (isBusy) {

--- a/src/Controller/KitController.php
+++ b/src/Controller/KitController.php
@@ -939,7 +939,8 @@ class KitController extends AbstractController
                         'Reposición de botiquín ' . ($unit->getAlias() ?: $unit->getSerialNumber()),
                         null,
                         $unitToMove,
-                        $batch
+                        $batch,
+                        $stockToMove
                     );
                 }
                 $entityManager->flush();

--- a/src/Service/MaterialManager.php
+++ b/src/Service/MaterialManager.php
@@ -208,7 +208,8 @@ class MaterialManager
         string $reason,
         ?Volunteer $responsible,
         ?MaterialUnit $unit = null,
-        ?MaterialBatch $batch = null
+        ?MaterialBatch $batch = null,
+        ?MaterialStock $stock = null
     ): void {
         $now = new \DateTimeImmutable();
         $entryReason = $destination ? sprintf('Entrada: Registro Inicial / %s', $destination->getName()) : 'Entrada: Registro Inicial';
@@ -244,8 +245,13 @@ class MaterialManager
                     $this->recordMovement($material, $quantity, $entryReason, null, $destination, $responsible, $batch, $now, false, $unit);
                 }
             }
-        } elseif ($material->getNature() === Material::NATURE_CONSUMABLE && $origin) {
+        } elseif ($material->getNature() === Material::NATURE_CONSUMABLE && ($origin || $stock)) {
             $remainingToSubtract = $quantity;
+
+            if ($stock) {
+                $origin = $stock->getLocation();
+                $batch = $stock->getBatch();
+            }
 
             if ($batch) {
                 $this->updateStockWithBatch($material, $origin, -$quantity, $batch);

--- a/templates/kit/refill_preview.html.twig
+++ b/templates/kit/refill_preview.html.twig
@@ -103,7 +103,7 @@
                                                 {% for opt in warehouseOptions[p.material.id] %}
                                                     {% set isSelected = false %}
                                                     {% if p.material.nature == 'CONSUMIBLE' %}
-                                                        {% if p.stock_id is defined and opt.stock_id|default(null) == p.stock_id %}
+                                                        {% if p.stock_id is defined and opt.id == p.stock_id %}
                                                             {% set isSelected = true %}
                                                         {% elseif p.stock_id is not defined and opt.selected|default(false) %}
                                                             {% set isSelected = true %}

--- a/tests/Service/KitTransferTest.php
+++ b/tests/Service/KitTransferTest.php
@@ -141,6 +141,59 @@ class KitTransferTest extends TestCase
         $this->assertStringContainsString('Traspaso', $movements[0]->getReason());
     }
 
+    public function testTransferWithExplicitStock(): void
+    {
+        // 1. Setup
+        $material = new Material();
+        $material->setName('M1');
+        $material->setNature(Material::NATURE_CONSUMABLE);
+
+        $locA = new Location();
+        $locA->setName('Loc A');
+
+        $stock = new MaterialStock();
+        $stock->setMaterial($material);
+        $stock->setLocation($locA);
+        $stock->setQuantity(10);
+        $locA->addStock($stock);
+
+        $locB = new Location();
+        $locB->setName('Loc B');
+
+        // 2. Mocks
+        $this->stockRepository->method('findOneBy')->willReturnCallback(function($criteria) use ($locA, $stock, $locB) {
+            if ($criteria['location'] === $locA) return $stock;
+            return null;
+        });
+
+        $query = $this->getMockBuilder(\Doctrine\ORM\Query::class)->disableOriginalConstructor()->getMock();
+        $query->method('getResult')->willReturn([]);
+        $qb = $this->createMock(\Doctrine\ORM\QueryBuilder::class);
+        $qb->method('where')->willReturnSelf(); $qb->method('andWhere')->willReturnSelf(); $qb->method('setParameter')->willReturnSelf(); $qb->method('getQuery')->willReturn($query);
+        $this->movementRepository->method('createQueryBuilder')->willReturn($qb);
+
+        // 3. Action: Transfer using EXPLICIT stock object
+        // We pass NULL for origin to prove it resolves from $stock
+        $this->materialManager->transfer(
+            $material,
+            null,
+            $locB,
+            4,
+            'Reason',
+            null,
+            null,
+            null,
+            $stock
+        );
+
+        // 4. Assertions
+        $this->assertEquals(6, $stock->getQuantity());
+        $stockB = null;
+        foreach ($locB->getStocks() as $s) { $stockB = $s; break; }
+        $this->assertNotNull($stockB);
+        $this->assertEquals(4, $stockB->getQuantity());
+    }
+
     public function testTransferBetweenKitsTechnical(): void
     {
         // 1. Setup Material


### PR DESCRIPTION
- Enhanced MaterialManager::transfer to support an optional MaterialStock object for precise origin resolution.
- Fixed KitController and refill_preview.html.twig to use unique MaterialStock IDs in consumable selections.
- Added validation to kit-refill_controller.js to prevent submitting rows with invalid or missing stock.
- Resolved "Stock insuficiente" errors caused by incorrect origin fallback logic.
- Updated unit tests to verify explicit stock transfer functionality.