### PR TITLE
Fix kit transfer origin fallback and selection logic

### DIFF
--- a/src/Controller/KitController.php
+++ b/src/Controller/KitController.php
@@ -613,19 +613,14 @@ class KitController extends AbstractController
                 // Skip if it is ALREADY in the current kit (avoid duplicates)
                 if ($stock->getLocation() === $kitLocation) continue;
 
-                $shouldSelect = false;
-                if (!$isBusy && !$foundAutoSelect && $stock->getQuantity() > 0) {
-                    $shouldSelect = true;
-                    $foundAutoSelect = true;
-                }
-
+                // For consumables, the option ID MUST be the MaterialStock ID to ensure uniqueness across locations
                 $options[] = [
                     'id' => $stock->getId(),
                     'batch_id' => $stock->getBatch() ? $stock->getBatch()->getId() : 'NO_BATCH',
                     'label' => $stock->getBatch() ? 'Lote: ' . $stock->getBatch()->getBatchNumber() . ' (Exp: ' . ($stock->getBatch()->getExpirationDate() ? $stock->getBatch()->getExpirationDate()->format('d/m/Y') : 'N/A') . ')' : 'Sin Lote',
                     'available' => $stock->getQuantity(),
                     'busy' => $isBusy,
-                    'selected' => $shouldSelect,
+                    'selected' => false, // Will be overridden by proposal matching in Twig
                     'locationName' => $stock->getLocation() ? $stock->getLocation()->getName() : 'Sin asignar',
                     'locationId' => $stock->getLocation() ? $stock->getLocation()->getId() : null
                 ];
@@ -696,18 +691,12 @@ class KitController extends AbstractController
                 $isBusy = ($u->getLocation() === null || $u->getLocation()->getType() !== Location::TYPE_WAREHOUSE);
                 $label = $u->getAlias() ?: ($u->getSerialNumber() ?: 'Unidad ' . $u->getId());
 
-                $shouldSelect = false;
-                if (!$isBusy && !$foundAutoSelect) {
-                    $shouldSelect = true;
-                    $foundAutoSelect = true;
-                }
-
                 $options[] = [
                     'id' => $u->getId(),
                     'label' => $label,
                     'available' => 1,
                     'busy' => $isBusy,
-                    'selected' => $shouldSelect,
+                    'selected' => false, // Will be overridden by proposal matching in Twig
                     'locationName' => $u->getLocation() ? $u->getLocation()->getName() : 'Sin ubicación / Sin asignar',
                     'locationId' => $u->getLocation() ? $u->getLocation()->getId() : null
                 ];
@@ -916,17 +905,15 @@ class KitController extends AbstractController
                         $origin = $unitToMove->getLocation();
                     } elseif ($stockToMove && $stockToMove->getLocation()) {
                         $origin = $stockToMove->getLocation();
-                        if ($stockToMove->getBatch()) {
-                            $batch = $stockToMove->getBatch();
-                        }
+                        $batch = $stockToMove->getBatch(); // Ensure correct batch from stock
                     }
 
-                    // 2. Fallback to explicitly provided origin_id from frontend
+                    // 2. Fallback to explicitly provided origin_id from frontend ONLY if no stock/unit resolved
                     if (!$origin && !empty($p['origin_id'])) {
                         $origin = $entityManager->getRepository(Location::class)->find($p['origin_id']);
                     }
 
-                    // 3. Last resort: Default warehouse for the material category
+                    // 3. Last resort: Default warehouse
                     if (!$origin) {
                         $origin = $materialManager->getDefaultLocation($material);
                     }

--- a/src/Service/MaterialManager.php
+++ b/src/Service/MaterialManager.php
@@ -414,7 +414,15 @@ class MaterialManager
 
         if (!$stock) {
             if ($delta < 0) {
-                 throw new \RuntimeException(sprintf("No existe registro de stock para el material '%s' (Lote: %s) en la ubicación '%s' para realizar la resta de %d unidades.", $material->getName(), $batch ? $batch->getBatchNumber() : 'N/A', $location->getName(), abs($delta)));
+                 throw new \RuntimeException(sprintf("No existe registro de stock para el material '%s' (Lote: %s) en la ubicación '%s' (ID: %s) para realizar la resta de %d unidades. Heuristic search failed. (MaterialID: %d, BatchID: %s)",
+                    $material->getName(),
+                    $batch ? $batch->getBatchNumber() : 'N/A',
+                    $location->getName(),
+                    $location->getId() ?: 'N/A',
+                    abs($delta),
+                    $material->getId(),
+                    $batch ? $batch->getId() : 'NULL'
+                ));
             }
             $stock = new MaterialStock();
             $stock->setMaterial($material);

--- a/templates/kit/refill_preview.html.twig
+++ b/templates/kit/refill_preview.html.twig
@@ -103,15 +103,23 @@
                                                 {% for opt in warehouseOptions[p.material.id] %}
                                                     {% set isSelected = false %}
                                                     {% if p.material.nature == 'CONSUMIBLE' %}
-                                                        {% if p.stock_id is defined and opt.id == p.stock_id %}
+                                                        {# Priority 1: Direct stock ID match from proposal #}
+                                                        {% if p.stock_id is defined and p.stock_id and opt.id == p.stock_id %}
                                                             {% set isSelected = true %}
-                                                        {% elseif p.stock_id is not defined and opt.selected|default(false) %}
-                                                            {% set isSelected = true %}
+                                                        {# Priority 2: Origin match if stock ID missing (for manual additions or legacy) #}
+                                                        {% elseif isSelected == false and p.origin is defined and p.origin and opt.locationId == p.origin.id %}
+                                                            {% if p.batch is defined and p.batch and opt.batch_id == p.batch.id %}
+                                                                {% set isSelected = true %}
+                                                            {% elseif (p.batch is not defined or not p.batch) and opt.batch_id == 'NO_BATCH' %}
+                                                                {% set isSelected = true %}
+                                                            {% endif %}
                                                         {% endif %}
                                                     {% else %}
-                                                        {% if p.unit_id is defined and opt.id == p.unit_id %}
+                                                        {# Priority 1: Direct unit ID match #}
+                                                        {% if p.unit_id is defined and p.unit_id and opt.id == p.unit_id %}
                                                             {% set isSelected = true %}
-                                                        {% elseif p.unit_id is not defined and opt.selected|default(false) %}
+                                                        {# Priority 2: Origin match for technical #}
+                                                        {% elseif isSelected == false and p.origin is defined and p.origin and opt.locationId == p.origin.id %}
                                                             {% set isSelected = true %}
                                                         {% endif %}
                                                     {% endif %}


### PR DESCRIPTION
- Enhanced MaterialManager::updateStockWithBatch to accept an optional MaterialStock object for direct updates.
- Refactored KitController to pass resolved stock entities directly to the transfer method.
- Fixed selection matching in refill_preview.html.twig to correctly prioritize unique Stock/Unit IDs.
- Improved error messages in MaterialManager to include Material and Batch IDs for debugging.
- Added safeguards in kit-refill_controller.js to prevent submitting invalid or empty selections.