### PR TITLE
Fix entity identity resolution in kit transfers

### DIFF
--- a/assets/controllers/kit-refill_controller.js
+++ b/assets/controllers/kit-refill_controller.js
@@ -218,8 +218,8 @@ export default class extends Controller {
 
             const selectedOption = identifierSelect.options[identifierSelect.selectedIndex];
             if (!selectedOption || !selectedOption.value) return;
-            const isBusy = selectedOption.dataset.busy === 'true';
 
+            const isBusy = selectedOption.dataset.busy === 'true';
             if (isBusy) {
                 hasBusy = true;
                 busyDetails.push({
@@ -228,13 +228,12 @@ export default class extends Controller {
                 });
             }
 
-            const selectedOption = identifierSelect.options[identifierSelect.selectedIndex];
             const proposal = {
                 material_id: materialId,
                 origin_id: selectedOption.dataset.locationId || this.originIdValue,
                 stock_id: nature === 'CONSUMIBLE' ? selectedOption.value : null,
                 quantity: quantity,
-                batch_id: nature === 'CONSUMIBLE' ? (selectedOption.dataset.batchId === 'NO_BATCH' ? null : selectedOption.dataset.batchId) : null,
+                batch_id: selectedOption.dataset.batchId && selectedOption.dataset.batchId !== 'NO_BATCH' ? selectedOption.dataset.batchId : null,
                 unit_id: nature === 'EQUIPO_TECNICO' ? selectedOption.value : null
             };
             proposals.push(proposal);

--- a/src/Controller/KitController.php
+++ b/src/Controller/KitController.php
@@ -890,30 +890,41 @@ class KitController extends AbstractController
         }
 
         try {
-            $entityManager->wrapInTransaction(function() use ($proposals, $entityManager, $materialManager, $kitLocation, $unit) {
+            $entityManager->wrapInTransaction(function() use ($proposals, $entityManager, $materialManager, $kitLocation, $unit, $proposalsData) {
                 foreach ($proposals as $p) {
-                    $material = $entityManager->getRepository(Material::class)->find($p['material_id']);
+                    $materialId = (int)($p['material_id'] ?? 0);
+                    if (!$materialId) continue;
+
+                    $material = $entityManager->getRepository(Material::class)->find($materialId);
                     if (!$material) continue;
 
-                    $batch = !empty($p['batch_id']) ? $entityManager->getRepository(\App\Entity\MaterialBatch::class)->find($p['batch_id']) : null;
-                    $unitToMove = !empty($p['unit_id']) ? $entityManager->getRepository(MaterialUnit::class)->find($p['unit_id']) : null;
-                    $stockToMove = !empty($p['stock_id']) ? $entityManager->getRepository(MaterialStock::class)->find($p['stock_id']) : null;
+                    // Use integer casting for IDs to ensure exact matching in repository
+                    $batchId = !empty($p['batch_id']) && is_numeric($p['batch_id']) ? (int)$p['batch_id'] : null;
+                    $unitId = !empty($p['unit_id']) && is_numeric($p['unit_id']) ? (int)$p['unit_id'] : null;
+                    $stockId = !empty($p['stock_id']) && is_numeric($p['stock_id']) ? (int)$p['stock_id'] : null;
 
-                    // 1. Prioritize location from the specific unit/stock being moved
+                    $batch = $batchId ? $entityManager->getRepository(\App\Entity\MaterialBatch::class)->find($batchId) : null;
+                    $unitToMove = $unitId ? $entityManager->getRepository(MaterialUnit::class)->find($unitId) : null;
+                    $stockToMove = $stockId ? $entityManager->getRepository(MaterialStock::class)->find($stockId) : null;
+
+                    // 1. Resolve Origin and Batch with Absolute Priority
                     $origin = null;
-                    if ($unitToMove && $unitToMove->getLocation()) {
-                        $origin = $unitToMove->getLocation();
-                    } elseif ($stockToMove && $stockToMove->getLocation()) {
+
+                    if ($stockToMove) {
+                        // Consumable from specific record
                         $origin = $stockToMove->getLocation();
-                        $batch = $stockToMove->getBatch(); // Ensure correct batch from stock
+                        $batch = $stockToMove->getBatch();
+                    } elseif ($unitToMove) {
+                        // Technical equipment from specific unit
+                        $origin = $unitToMove->getLocation();
                     }
 
-                    // 2. Fallback to explicitly provided origin_id from frontend ONLY if no stock/unit resolved
-                    if (!$origin && !empty($p['origin_id'])) {
-                        $origin = $entityManager->getRepository(Location::class)->find($p['origin_id']);
+                    // 2. Resolve Fallback Origin ONLY if no specific record found
+                    if (!$origin && !empty($p['origin_id']) && is_numeric($p['origin_id'])) {
+                        $origin = $entityManager->getRepository(Location::class)->find((int)$p['origin_id']);
                     }
 
-                    // 3. Last resort: Default warehouse
+                    // 3. Absolute Last resort: Default warehouse
                     if (!$origin) {
                         $origin = $materialManager->getDefaultLocation($material);
                     }
@@ -934,6 +945,10 @@ class KitController extends AbstractController
             });
         } catch (\Exception $e) {
             $this->addFlash('error', 'Error al procesar el traslado: ' . $e->getMessage());
+            // Log the payload for debugging if it's a critical logic error
+            if (str_contains($e->getMessage(), 'Heuristic') || str_contains($e->getMessage(), 'insuficiente') || str_contains($e->getMessage(), 'registro de stock')) {
+                $this->addFlash('info', 'DEBUG DATA (Proposals Payload): ' . $proposalsData);
+            }
             return $this->redirectToRoute('app_kit_inventory', ['id' => $unit->getId()]);
         }
 

--- a/src/Service/MaterialManager.php
+++ b/src/Service/MaterialManager.php
@@ -397,8 +397,15 @@ class MaterialManager
             if (isset($this->stocksCache[$cacheKey])) {
                 $stock = $this->stocksCache[$cacheKey];
             } else {
+                // Robust comparison using IDs to handle Doctrine Proxies and different object identities
+                $targetMatId = $material->getId();
+                $targetBatchId = $batch ? $batch->getId() : null;
+
                 foreach ($location->getStocks() as $s) {
-                    if ($s->getMaterial() === $material && $s->getBatch() === $batch) {
+                    $sMatId = $s->getMaterial() ? $s->getMaterial()->getId() : null;
+                    $sBatchId = $s->getBatch() ? $s->getBatch()->getId() : null;
+
+                    if ($sMatId === $targetMatId && $sBatchId === $targetBatchId) {
                         $stock = $s;
                         $this->stocksCache[$cacheKey] = $stock;
                         break;
@@ -438,7 +445,17 @@ class MaterialManager
 
         $newQuantity = $stock->getQuantity() + $delta;
         if ($newQuantity < 0) {
-            throw new \RuntimeException(sprintf("Stock insuficiente para el material '%s' (Lote: %s) en la ubicación '%s' (ID: %s). Disponible: %d, Solicitado: %d", $material->getName(), $batch ? $batch->getBatchNumber() : 'N/A', $location->getName(), $location->getId() ?: 'N/A', $stock->getQuantity(), abs($delta)));
+            throw new \RuntimeException(sprintf(
+                "Stock insuficiente para el material '%s' (ID:%d) (LoteID:%s) en la ubicación '%s' (ID:%s). Disponible:%d, Solicitado:%d. (StockObject: %s)",
+                $material->getName(),
+                $material->getId(),
+                $batch ? $batch->getId() : 'NULL',
+                $location->getName(),
+                $location->getId() ?: 'N/A',
+                $stock->getQuantity(),
+                abs($delta),
+                $stock ? 'YES' : 'NO'
+            ));
         }
 
         if ($newQuantity == 0 && $location->getType() !== Location::TYPE_WAREHOUSE) {


### PR DESCRIPTION
- Refactored MaterialManager::updateStockWithBatch to use ID-based comparisons, ensuring compatibility with Doctrine Proxy objects and different entity instances.
- Fixed serialization logic in kit-refill_controller.js to correctly transmit both stock_id and batch_id to the backend.
- Added detailed diagnostic feedback in KitController to display the raw proposal payload if a transfer fails.
- Ensured absolute priority for origin resolution from physical entities, preventing incorrect fallbacks to default warehouses.