### PR TITLE
Fix inventory traceability and official kit template logic

### DIFF
--- a/src/Controller/MaterialController.php
+++ b/src/Controller/MaterialController.php
@@ -156,7 +156,7 @@ class MaterialController extends AbstractController
 
                     $batch->setBatchNumber($batchNumber);
                     if (!empty($bData['expirationDate'])) {
-                        $batch->setExpirationDate(new \DateTimeImmutable($bData['expirationDate']));
+                        $batch->setExpirationDate(new \DateTime($bData['expirationDate']));
                     }
                     $batch->setSupplier($bData['supplier'] ?? null);
                     $batch->setUnitsPerPackage($unitsPerPackage);
@@ -224,10 +224,10 @@ class MaterialController extends AbstractController
                     $first = $unitsData[0];
                     if (isset($first['brandModel'])) $material->setBrandModel($first['brandModel']);
                     if (!empty($first['purchaseDate'])) {
-                        $material->setPurchaseDate(new \DateTimeImmutable($first['purchaseDate']));
+                        $material->setPurchaseDate(new \DateTime($first['purchaseDate']));
                     }
                     if (!empty($first['warrantyDate'])) {
-                        $material->setWarrantyEndDate(new \DateTimeImmutable($first['warrantyDate']));
+                        $material->setWarrantyDate(new \DateTime($first['warrantyDate']));
                     }
                 }
 
@@ -458,7 +458,7 @@ class MaterialController extends AbstractController
         if ($material->getNature() === Material::NATURE_TECHNICAL) {
             foreach ($material->getUnits() as $unit) {
                 $pDate = $unit->getPurchaseDate() ? $unit->getPurchaseDate()->format('Y-m-d') : 'none';
-                $wDate = $unit->getWarrantyEndDate() ? $unit->getWarrantyEndDate()->format('Y-m-d') : 'none';
+                $wDate = $unit->getWarrantyDate() ? $unit->getWarrantyDate()->format('Y-m-d') : 'none';
                 $key = ($unit->getSerialNumber() ?: 'no-sn') . '_' . $pDate . '_' . $wDate;
 
                 if (!isset($groupedUnits[$key])) {
@@ -466,7 +466,7 @@ class MaterialController extends AbstractController
                         'sn' => $unit->getSerialNumber(),
                         'model' => $unit->getBrandModel() ?: $material->getBrandModel(),
                         'purchaseDate' => $unit->getPurchaseDate(),
-                        'warrantyDate' => $unit->getWarrantyEndDate(),
+                        'warrantyDate' => $unit->getWarrantyDate(),
                         'count' => 0,
                         'valuation' => 0.0
                     ];
@@ -584,7 +584,7 @@ class MaterialController extends AbstractController
 
                     $batch->setBatchNumber($batchNumber);
                     if (!empty($bData['expirationDate'])) {
-                        $batch->setExpirationDate(new \DateTimeImmutable($bData['expirationDate']));
+                        $batch->setExpirationDate(new \DateTime($bData['expirationDate']));
                     }
                     $batch->setSupplier($bData['supplier'] ?? null);
 
@@ -688,10 +688,10 @@ class MaterialController extends AbstractController
                     $first = $unitsData[0];
                     if (isset($first['brandModel'])) $material->setBrandModel($first['brandModel']);
                     if (!empty($first['purchaseDate'])) {
-                        $material->setPurchaseDate(new \DateTimeImmutable($first['purchaseDate']));
+                        $material->setPurchaseDate(new \DateTime($first['purchaseDate']));
                     }
                     if (!empty($first['warrantyDate'])) {
-                        $material->setWarrantyEndDate(new \DateTimeImmutable($first['warrantyDate']));
+                        $material->setWarrantyDate(new \DateTime($first['warrantyDate']));
                     }
                     if (isset($first['operationalStatus'])) {
                         $material->setOperationalStatus($first['operationalStatus']);
@@ -750,7 +750,7 @@ class MaterialController extends AbstractController
                     'serialNumber' => $unit->getSerialNumber(),
                     'brandModel' => $material->getBrandModel(),
                     'purchaseDate' => $material->getPurchaseDate() ? $material->getPurchaseDate()->format('Y-m-d') : null,
-                    'warrantyDate' => $material->getWarrantyEndDate() ? $material->getWarrantyEndDate()->format('Y-m-d') : null,
+                    'warrantyDate' => $material->getWarrantyDate() ? $material->getWarrantyDate()->format('Y-m-d') : null,
                     'operationalStatus' => $unit->getOperationalStatus(),
                     'batteryStatus' => $unit->getBatteryStatus(),
                     'networkId' => $unit->getNetworkId(),

--- a/src/Service/ExcelImportService.php
+++ b/src/Service/ExcelImportService.php
@@ -391,7 +391,7 @@ class ExcelImportService
                 if ($networkId && $networkId !== 'S/N') $material->setNetworkId($networkId);
                 if ($phoneNumber) $material->setPhoneNumber($phoneNumber);
                 if ($purchaseDate) $material->setPurchaseDate($purchaseDate);
-                if ($warrantyDate) $material->setWarrantyEndDate($warrantyDate);
+                if ($warrantyDate) $material->setWarrantyDate($warrantyDate);
                 if ($description) $material->setDescription($description);
 
                 // Handle Image

--- a/src/Service/MaterialManager.php
+++ b/src/Service/MaterialManager.php
@@ -182,7 +182,7 @@ class MaterialManager
         $unit->setBatteryStatus($data['battery_status'] ?? $data['batteryStatus'] ?? '100%');
 
         if (isset($data['purchaseDate'])) $unit->setPurchaseDate($data['purchaseDate']);
-        if (isset($data['warrantyDate'])) $unit->setWarrantyEndDate($data['warrantyDate']);
+        if (isset($data['warrantyDate'])) $unit->setWarrantyDate($data['warrantyDate']);
         if (isset($data['hasCharger'])) $unit->setHasCharger($data['hasCharger']);
         if (isset($data['hasClip'])) $unit->setHasClip($data['hasClip']);
         if (isset($data['hasMicrophone'])) $unit->setHasMicrophone($data['hasMicrophone']);

--- a/templates/material/edit.html.twig
+++ b/templates/material/edit.html.twig
@@ -132,7 +132,10 @@
                             </div>
                         </div>
                         <div class="row mt-2">
-                            <div class="col-md-6">{{ form_row(form.brandModel, {'label': 'MARCA / MODELO'}) }}</div>
+                            <div class="col-md-6">
+                                <label class="form-label">Marca / Modelo</label>
+                                {{ form_widget(form.brandModel, {'attr': {'class': 'form-input'}}) }}
+                            </div>
                             <div class="col-md-6">{{ form_row(form.nature, {'label': 'NATURALEZA*'}) }}</div>
                         </div>
                         <div class="row mt-2">
@@ -263,9 +266,9 @@
                 </div>
                 <div class="card-body">
                     <div class="row">
-                        <div class="col-md-6 mb-3">
+                        <div class="col-md-6 mb-3 d-none">
                             <label class="form-label">Marca y Modelo</label>
-                            {{ form_widget(form.brandModel, {'attr': {'class': 'form-input'}}) }}
+                            <div class="d-none">{{ form_row(form.brandModel) }}</div>
                         </div>
                         <div class="col-md-6 mb-3">
                             <label class="form-label">Número de Serie (S/N)</label>


### PR DESCRIPTION
- Renamed warrantyEndDate to warrantyDate across entities, forms, and templates.
- Migrated date fields to \DateTime for improved compatibility.
- Fixed 500 error in MaterialController caused by legacy method calls.
- Resolved Twig rendering conflict for brandModel in edit view.
- Enhanced ExcelImportService with duplicate Alias validation in preview.
- Updated seeding logic with official "Mochila SVB Básica" standards.
- Refactored Detail view to show individual physical units (MaterialUnit).