### PR TITLE
Fix Material Index error and implement suggested kit templates

### DIFF
--- a/src/Command/SeedServicesCommand.php
+++ b/src/Command/SeedServicesCommand.php
@@ -203,13 +203,15 @@ class SeedServicesCommand extends Command
             ];
 
             foreach ($kitItems as $itemData) {
+                $item = new KitTemplateItem();
                 if (isset($materialMap[$itemData['name']])) {
-                    $item = new KitTemplateItem();
                     $item->setMaterial($materialMap[$itemData['name']]);
-                    $item->setQuantity($itemData['qty']);
-                    $item->setTemplate($template);
-                    $this->entityManager->persist($item);
+                } else {
+                    $item->setSuggestedName($itemData['name']);
                 }
+                $item->setQuantity($itemData['qty']);
+                $item->setTemplate($template);
+                $this->entityManager->persist($item);
             }
         }
 

--- a/src/Controller/KitController.php
+++ b/src/Controller/KitController.php
@@ -130,17 +130,14 @@ class KitController extends AbstractController
             if (!empty($data['items'])) {
                 foreach ($data['items'] as $itemData) {
                     $material = $entityManager->getRepository(Material::class)->findOneBy(['name' => $itemData['name']]);
-                    if (!$material) {
-                        $material = new Material();
-                        $material->setName($itemData['name']);
-                        $material->setCategory('Sanitario');
-                        $material->setNature($itemData['nature']);
-                        $entityManager->persist($material);
-                    }
 
                     $exists = false;
                     foreach ($template->getItems() as $existingItem) {
-                        if ($existingItem->getMaterial() === $material) {
+                        if ($material && $existingItem->getMaterial() === $material) {
+                            $existingItem->setQuantity($itemData['qty']);
+                            $exists = true;
+                            break;
+                        } elseif (!$material && $existingItem->getSuggestedName() === $itemData['name']) {
                             $existingItem->setQuantity($itemData['qty']);
                             $exists = true;
                             break;
@@ -149,7 +146,11 @@ class KitController extends AbstractController
 
                     if (!$exists) {
                         $item = new KitTemplateItem();
-                        $item->setMaterial($material);
+                        if ($material) {
+                            $item->setMaterial($material);
+                        } else {
+                            $item->setSuggestedName($itemData['name']);
+                        }
                         $item->setQuantity($itemData['qty']);
                         $template->addItem($item);
                         $entityManager->persist($item);
@@ -182,13 +183,16 @@ class KitController extends AbstractController
             $template->setDescription($description);
 
             foreach ($items as $itemData) {
-                if (empty($itemData['material']) || empty($itemData['quantity'])) continue;
-
-                $material = $entityManager->getRepository(Material::class)->find($itemData['material']);
-                if (!$material) continue;
+                if ((empty($itemData['material']) && empty($itemData['suggested_name'])) || empty($itemData['quantity'])) continue;
 
                 $item = new KitTemplateItem();
-                $item->setMaterial($material);
+                if (!empty($itemData['material'])) {
+                    $material = $entityManager->getRepository(Material::class)->find($itemData['material']);
+                    if ($material) $item->setMaterial($material);
+                } else {
+                    $item->setSuggestedName($itemData['suggested_name']);
+                }
+
                 $item->setQuantity((int)$itemData['quantity']);
                 $template->addItem($item);
             }
@@ -260,10 +264,14 @@ class KitController extends AbstractController
             $template->getItems()->clear();
 
             foreach ($items as $itemData) {
-                if (empty($itemData['material']) || empty($itemData['quantity'])) continue;
+                if ((empty($itemData['material']) && empty($itemData['suggested_name'])) || empty($itemData['quantity'])) continue;
 
                 $item = new KitTemplateItem();
-                $item->setMaterial($entityManager->getReference(Material::class, $itemData['material']));
+                if (!empty($itemData['material'])) {
+                    $item->setMaterial($entityManager->getReference(Material::class, $itemData['material']));
+                } else {
+                    $item->setSuggestedName($itemData['suggested_name']);
+                }
                 $item->setQuantity((int)$itemData['quantity']);
                 $template->addItem($item);
             }
@@ -416,6 +424,7 @@ class KitController extends AbstractController
 
         foreach ($template->getItems() as $item) {
             $material = $item->getMaterial();
+            if (!$material) continue; // Skip items that are only suggestions for now in auto-refill logic
             $defaultWarehouse = $materialManager->getDefaultLocation($material);
             $this->addMaterialOptionsToRefill($material, $unit, $dummyLocation, $defaultWarehouse, $proposals, $shortages, $warehouseOptions, $entityManager, $item->getQuantity());
         }
@@ -576,6 +585,7 @@ class KitController extends AbstractController
         // 2. Proposals for items IN THE TEMPLATE (FIFO)
         foreach ($template->getItems() as $item) {
             $material = $item->getMaterial();
+            if (!$material) continue; // Skip suggestions
             $defaultWarehouse = $materialManager->getDefaultLocation($material);
             $this->addMaterialOptionsToRefill($material, $unit, $kitLocation, $defaultWarehouse, $proposals, $shortages, $warehouseOptions, $entityManager, $item->getQuantity());
         }

--- a/src/Entity/KitTemplateItem.php
+++ b/src/Entity/KitTemplateItem.php
@@ -18,8 +18,11 @@ class KitTemplateItem
     private ?KitTemplate $template = null;
 
     #[ORM\ManyToOne]
-    #[ORM\JoinColumn(nullable: false)]
+    #[ORM\JoinColumn(nullable: true)]
     private ?Material $material = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $suggestedName = null;
 
     #[ORM\Column]
     private ?int $quantity = null;
@@ -48,6 +51,17 @@ class KitTemplateItem
     public function setMaterial(?Material $material): static
     {
         $this->material = $material;
+        return $this;
+    }
+
+    public function getSuggestedName(): ?string
+    {
+        return $this->suggestedName;
+    }
+
+    public function setSuggestedName(?string $suggestedName): static
+    {
+        $this->suggestedName = $suggestedName;
         return $this;
     }
 

--- a/templates/kit/template_edit.html.twig
+++ b/templates/kit/template_edit.html.twig
@@ -65,12 +65,27 @@
                                     {% for item in template.items %}
                                         <tr class="kit-item-row">
                                             <td class="ps-4">
-                                                <select name="items[{{ loop.index0 }}][material]" class="form-select form-select-sm material-select" data-action="change->kit-template#filterOptions" required>
-                                                    <option value="" disabled>Selecciona material...</option>
-                                                    {% for material in materials %}
-                                                        <option value="{{ material.id }}" {{ item.material.id == material.id ? 'selected' : '' }}>{{ material.name }}</option>
-                                                    {% endfor %}
-                                                </select>
+                                                {% if item.material %}
+                                                    <select name="items[{{ loop.index0 }}][material]" class="form-select form-select-sm material-select" data-action="change->kit-template#filterOptions" required>
+                                                        <option value="" disabled>Selecciona material...</option>
+                                                        {% for material in materials %}
+                                                            <option value="{{ material.id }}" {{ item.material.id == material.id ? 'selected' : '' }}>{{ material.name }}</option>
+                                                        {% endfor %}
+                                                    </select>
+                                                {% else %}
+                                                    <div class="input-group input-group-sm">
+                                                        <span class="input-group-text bg-warning-soft text-warning" title="Material no registrado" data-bs-toggle="tooltip">
+                                                            <i data-lucide="help-circle" class="w-3 h-3"></i>
+                                                        </span>
+                                                        <input type="text" name="items[{{ loop.index0 }}][suggested_name]" class="form-control font-bold" value="{{ item.suggestedName }}" placeholder="Nombre sugerido">
+                                                        <select name="items[{{ loop.index0 }}][material]" class="form-select material-select" style="max-width: 40px;" data-action="change->kit-template#filterOptions">
+                                                            <option value="">Vincular...</option>
+                                                            {% for material in materials %}
+                                                                <option value="{{ material.id }}">{{ material.name }}</option>
+                                                            {% endfor %}
+                                                        </select>
+                                                    </div>
+                                                {% endif %}
                                             </td>
                                             <td class="pe-4">
                                                 <div class="input-group input-group-sm">


### PR DESCRIPTION
- Resolved Twig syntax error in Material Index.
- Updated KitTemplateItem to allow suggestedNames for items not yet in inventory.
- Implemented default "Mochila SVB Básica" template with 29 suggested items.
- Updated UI to display and manage suggested items in kit templates.
- Aligned seeder logic with new suggested name philosophy.