### PR TITLE
Fix 500 errors and implement suggested kit templates

### DIFF
--- a/templates/kit/inventory.html.twig
+++ b/templates/kit/inventory.html.twig
@@ -116,41 +116,69 @@
 
                                 {# First, items in the template #}
                                 {% for item in unit.template.items %}
-                                    {% set mId = 'mat_' ~ item.material.id %}
-                                    {% set displayedMaterialIds = displayedMaterialIds|merge([mId]) %}
-                                    {% set currentQty = locationQuantities[mId] ?? 0 %}
-                                    <tr>
-                                        <td class="ps-4">
-                                            <div class="d-flex align-items-center">
-                                                {% if item.material.imagePath %}
-                                                    <img src="{{ asset('uploads/material/' ~ item.material.imagePath) }}" class="rounded-2 me-3" style="width: 40px; height: 40px; object-fit: cover;">
-                                                {% else %}
-                                                    <div class="bg-slate-100 rounded-2 me-3 flex items-center justify-center" style="width: 40px; height: 40px;">
-                                                        <i data-lucide="package" class="w-5 h-5 text-slate-400"></i>
+                                    {% if item.material %}
+                                        {% set mId = 'mat_' ~ item.material.id %}
+                                        {% set displayedMaterialIds = displayedMaterialIds|merge([mId]) %}
+                                        {% set currentQty = locationQuantities[mId] ?? 0 %}
+                                        <tr>
+                                            <td class="ps-4">
+                                                <div class="d-flex align-items-center">
+                                                    {% if item.material.imagePath %}
+                                                        <img src="{{ asset('uploads/material/' ~ item.material.imagePath) }}" class="rounded-2 me-3" style="width: 40px; height: 40px; object-fit: cover;">
+                                                    {% else %}
+                                                        <div class="bg-slate-100 rounded-2 me-3 flex items-center justify-center" style="width: 40px; height: 40px;">
+                                                            <i data-lucide="package" class="w-5 h-5 text-slate-400"></i>
+                                                        </div>
+                                                    {% endif %}
+                                                    <div>
+                                                        <div class="font-bold text-slate-800">{{ item.material.name }}</div>
+                                                        <div class="text-xxs text-slate-400 uppercase font-bold">{{ item.material.category }}</div>
                                                     </div>
-                                                {% endif %}
-                                                <div>
-                                                    <div class="font-bold text-slate-800">{{ item.material.name }}</div>
-                                                    <div class="text-xxs text-slate-400 uppercase font-bold">{{ item.material.category }}</div>
                                                 </div>
-                                            </div>
-                                        </td>
-                                        <td class="text-center">
-                                            {% set status = item.material.expirationStatus %}
-                                            <span class="w-3 h-3 rounded-full inline-block bg-{{ status == 'green' ? 'green' : (status == 'red' ? 'red' : (status == 'orange' ? 'orange' : 'yellow')) }}-500" title="Caducidad: {{ item.material.expirationDate ? item.material.expirationDate|date('d/m/Y') : 'N/A' }}"></span>
-                                        </td>
-                                        <td class="text-end font-monospace">
-                                            <span class="{% if currentQty < item.quantity %}text-red-600 font-bold{% endif %}">{{ currentQty }}</span>
-                                        </td>
-                                        <td class="text-end text-slate-400 font-monospace">
-                                            {{ item.quantity }}
-                                        </td>
-                                        <td class="text-end pe-4">
-                                            <a href="{{ path('app_material_transfer', {id: item.material.id, origin_id: unit.kitLocation.id}) }}" class="btn btn-xs btn-outline-secondary" title="Traspasar desde este botiquín">
-                                                <i data-lucide="move" class="w-3 h-3"></i>
-                                            </a>
-                                        </td>
-                                    </tr>
+                                            </td>
+                                            <td class="text-center">
+                                                {% set status = item.material.expirationStatus %}
+                                                <span class="w-3 h-3 rounded-full inline-block bg-{{ status == 'green' ? 'green' : (status == 'red' ? 'red' : (status == 'orange' ? 'orange' : 'yellow')) }}-500" title="Caducidad: {{ item.material.expirationDate ? item.material.expirationDate|date('d/m/Y') : 'N/A' }}"></span>
+                                            </td>
+                                            <td class="text-end font-monospace">
+                                                <span class="{% if currentQty < item.quantity %}text-red-600 font-bold{% endif %}">{{ currentQty }}</span>
+                                            </td>
+                                            <td class="text-end text-slate-400 font-monospace">
+                                                {{ item.quantity }}
+                                            </td>
+                                            <td class="text-end pe-4">
+                                                <a href="{{ path('app_material_transfer', {id: item.material.id, origin_id: unit.kitLocation.id}) }}" class="btn btn-xs btn-outline-secondary" title="Traspasar desde este botiquín">
+                                                    <i data-lucide="move" class="w-3 h-3"></i>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    {% else %}
+                                        <tr class="bg-red-50/30">
+                                            <td class="ps-4">
+                                                <div class="d-flex align-items-center">
+                                                    <div class="bg-slate-100 rounded-2 me-3 flex items-center justify-center" style="width: 40px; height: 40px;">
+                                                        <i data-lucide="help-circle" class="w-5 h-5 text-amber-500"></i>
+                                                    </div>
+                                                    <div>
+                                                        <div class="font-bold text-slate-800">{{ item.suggestedName }} <small class="text-slate-400 font-normal">(No registrado)</small></div>
+                                                        <div class="text-xxs text-amber-600 uppercase font-bold">Por registrar</div>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td class="text-center">
+                                                <span class="w-3 h-3 rounded-full inline-block bg-slate-200" title="Material no registrado en inventario"></span>
+                                            </td>
+                                            <td class="text-end font-monospace">
+                                                <span class="text-red-600 font-bold">0</span>
+                                            </td>
+                                            <td class="text-end text-slate-400 font-monospace">
+                                                {{ item.quantity }}
+                                            </td>
+                                            <td class="text-end pe-4">
+                                                <span class="text-xxs text-slate-400 italic">No disponible</span>
+                                            </td>
+                                        </tr>
+                                    {% endif %}
                                 {% endfor %}
 
                                 {# Then, extra items in the location #}

--- a/templates/kit/refill_preview.html.twig
+++ b/templates/kit/refill_preview.html.twig
@@ -74,22 +74,33 @@
                                 {% endfor %}
 
                                 {% for p in proposals %}
-                                    <tr class="refill-row {{ p.placeholder|default(false) ? 'opacity-75' : '' }}"
-                                        data-material-id="{{ p.material.id }}"
-                                        data-nature="{{ p.material.nature }}"
-                                        style="{{ p.placeholder|default(false) ? 'border-left: 3px solid #f87171;' : '' }}">
-                                        <td class="ps-4">
-                                            <div class="font-bold text-slate-800 dark:text-slate-200">
-                                                {% if p.unit is defined and p.unit and p.unit.alias %}
-                                                    {{ p.unit.alias }} <span class="text-slate-400 text-xxs font-normal">({{ p.material.name }})</span>
-                                                {% else %}
-                                                    {{ p.material.name }}
-                                                {% endif %}
-                                            </div>
-                                            <div class="text-xxs text-slate-400 dark:text-slate-500 uppercase font-black">{{ p.material.category }}</div>
-                                            <div class="location-label text-xxs font-bold mt-1"></div>
-                                            <input type="hidden" class="material-id" value="{{ p.material.id }}">
-                                        </td>
+                                    {% if p.material %}
+                                        <tr class="refill-row {{ p.placeholder|default(false) ? 'opacity-75' : '' }}"
+                                            data-material-id="{{ p.material.id }}"
+                                            data-nature="{{ p.material.nature }}"
+                                            style="{{ p.placeholder|default(false) ? 'border-left: 3px solid #f87171;' : '' }}">
+                                            <td class="ps-4">
+                                                <div class="font-bold text-slate-800 dark:text-slate-200">
+                                                    {% if p.unit is defined and p.unit and p.unit.alias %}
+                                                        {{ p.unit.alias }} <span class="text-slate-400 text-xxs font-normal">({{ p.material.name }})</span>
+                                                    {% else %}
+                                                        {{ p.material.name }}
+                                                    {% endif %}
+                                                </div>
+                                                <div class="text-xxs text-slate-400 dark:text-slate-500 uppercase font-black">{{ p.material.category }}</div>
+                                                <div class="location-label text-xxs font-bold mt-1"></div>
+                                                <input type="hidden" class="material-id" value="{{ p.material.id }}">
+                                            </td>
+                                    {% else %}
+                                        {# Handle items that are only suggested names (shouldn't happen in auto proposals but good for safety) #}
+                                        <tr class="refill-row opacity-50 bg-slate-50">
+                                            <td class="ps-4">
+                                                <div class="font-bold text-slate-400">
+                                                    {{ p.suggestedName|default('Item no registrado') }}
+                                                </div>
+                                                <div class="text-xxs text-slate-400 uppercase font-black">Sin Material Vinculado</div>
+                                            </td>
+                                    {% endif %}
                                         <td>
                                             <select class="form-select form-select-sm identifier-select dark:bg-slate-900/50 dark:border-slate-700 dark:text-slate-300" data-action="change->kit-refill#updateAvailable">
                                                 {% set target_id = null %}


### PR DESCRIPTION
- Resolved Twig syntax error in Material Index.
- Fixed TypeError in Excel import by converting DateTimeImmutable to DateTime.
- Implemented Suggested Items feature for Kit Templates (nullable material + suggestedName).
- Added default "Mochila SVB Básica" template with 29 items.
- Updated UI templates to handle suggested/non-registered items gracefully.
- Fixed MaterialBatch date type mismatches in MaterialController.
- Updated test mocks for FIFO stock resolution.