### PR TITLE
Fix inventory visibility, 500 errors and implement suggested kit items

### DIFF
--- a/src/Controller/MaterialController.php
+++ b/src/Controller/MaterialController.php
@@ -47,9 +47,11 @@ class MaterialController extends AbstractController
         }
 
         $materials = $qb->getQuery()->getResult();
+        $subFamilies = $materialRepository->findAllExistingSubFamilies($category);
 
         $response = $this->render('material/index.html.twig', [
             'materials' => $materials,
+            'subFamilies' => $subFamilies,
             'current_category' => $category,
             'current_subfamily' => $subFamily,
             'current_section' => 'recursos'
@@ -177,10 +179,10 @@ class MaterialController extends AbstractController
 
                     $entityManager->persist($batch);
 
-                    // Initialize stock for this batch in Central Warehouse
+                    // Initialize stock for this batch in Default Warehouse
                     $addedStock = $unitsPerPackage * $numPackagesInRow;
                     if ($addedStock > 0) {
-                        $materialManager->adjustStock($material, $addedStock, 'Entrada: Registro Inicial', $materialManager->getCentralWarehouse(), null, $batch);
+                        $materialManager->adjustStock($material, $addedStock, 'Entrada: Registro Inicial', $materialManager->getDefaultLocation($material), null, $batch);
                     }
                 }
             }
@@ -611,10 +613,10 @@ class MaterialController extends AbstractController
                         $batch->setUnitPrice((string)($price / $newTotalStock));
                     }
 
-                    // If stock changed, adjust it in Central Warehouse
+                    // If stock changed, adjust it in Default Warehouse
                     if ($newTotalStock !== $oldTotalStock) {
                         $diff = $newTotalStock - $oldTotalStock;
-                        $materialManager->adjustStock($material, $diff, 'Ajuste manual de stock', $materialManager->getCentralWarehouse(), null, $batch);
+                        $materialManager->adjustStock($material, $diff, 'Ajuste manual de stock', $materialManager->getDefaultLocation($material), null, $batch);
                     }
                 }
             }

--- a/src/Controller/WarehouseController.php
+++ b/src/Controller/WarehouseController.php
@@ -19,7 +19,24 @@ class WarehouseController extends AbstractController
         LocationReviewRepository $reviewRepository,
         \App\Repository\LocationRepository $locationRepository
     ): Response {
-        $materials = $materialRepository->findBy([], ['id' => 'DESC']);
+        // Eager load everything to prevent N+1 and ensure consistency
+        $materials = $materialRepository->createQueryBuilder('m')
+            ->leftJoin('m.stocks', 's')
+            ->addSelect('s')
+            ->leftJoin('s.location', 'sl')
+            ->addSelect('sl')
+            ->leftJoin('m.units', 'u')
+            ->addSelect('u')
+            ->leftJoin('u.location', 'ul')
+            ->addSelect('ul')
+            ->leftJoin('u.template', 'ut')
+            ->addSelect('ut')
+            ->leftJoin('m.batches', 'b')
+            ->addSelect('b')
+            ->orderBy('m.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+
         $vehicles = $vehicleRepository->findAll();
         // Filter out Almacén Central and orphaned/deleted KIT locations
         $locations = $locationRepository->createQueryBuilder('l')

--- a/src/Repository/MaterialRepository.php
+++ b/src/Repository/MaterialRepository.php
@@ -98,14 +98,19 @@ class MaterialRepository extends ServiceEntityRepository
     /**
      * Returns all unique subfamilies present in the material database.
      */
-    public function findAllExistingSubFamilies(): array
+    public function findAllExistingSubFamilies(?string $category = null): array
     {
-        $results = $this->createQueryBuilder('m')
+        $qb = $this->createQueryBuilder('m')
             ->select('DISTINCT m.subFamily')
             ->where('m.subFamily IS NOT NULL')
-            ->orderBy('m.subFamily', 'ASC')
-            ->getQuery()
-            ->getScalarResult();
+            ->orderBy('m.subFamily', 'ASC');
+
+        if ($category) {
+            $qb->andWhere('m.category = :category')
+               ->setParameter('category', $category);
+        }
+
+        $results = $qb->getQuery()->getScalarResult();
 
         return array_column($results, 'subFamily');
     }

--- a/templates/material/index.html.twig
+++ b/templates/material/index.html.twig
@@ -25,10 +25,10 @@
                     <input type="hidden" name="category" value="{{ current_category }}">
                 {% endif %}
 
-                {% if current_category == 'Sanitario' %}
+                {% if subFamilies|length > 0 %}
                     <select name="subFamily" class="form-select form-select-sm w-auto" onchange="this.form.submit()">
                         <option value="">Todas las familias...</option>
-                        {% for f in ['Analgésicos', 'Curas', 'Inmovilización', 'Medicación', 'Diagnóstico', 'Protección', 'Oxigenoterapia', 'Vía Aérea', 'Varios'] %}
+                        {% for f in subFamilies %}
                             <option value="{{ f }}" {{ current_subfamily == f ? 'selected' : '' }}>{{ f }}</option>
                         {% endfor %}
                     </select>

--- a/templates/warehouse/index.html.twig
+++ b/templates/warehouse/index.html.twig
@@ -104,7 +104,7 @@
                                         </tr>
                                     </thead>
                                     <tbody class="text-sm">
-                                        {% for material in materials|slice(0, 15) %}
+                                        {% for material in materials %}
                                         <tr>
                                             <td class="fw-bold">{{ material.name }}</td>
                                             <td>
@@ -118,15 +118,20 @@
                                             </td>
                                             <td>
                                                 {% set loc_totals = {} %}
+                                                {% set assigned_total = 0 %}
                                                 {% if material.nature == 'CONSUMIBLE' %}
                                                     {% for stock in material.stocks %}
-                                                        {% set loc_name = stock.location.name %}
+                                                        {% set loc_name = stock.location.name|default('Ubicación desconocida') %}
                                                         {% set loc_totals = loc_totals|merge({ (loc_name): (loc_totals[loc_name] ?? 0) + stock.quantity }) %}
+                                                        {% set assigned_total = assigned_total + stock.quantity %}
                                                     {% endfor %}
                                                 {% else %}
                                                     {% for unit in material.units %}
                                                         {% set loc_name = unit.location.name|default('Sin ubicación') %}
                                                         {% set loc_totals = loc_totals|merge({ (loc_name): (loc_totals[loc_name] ?? 0) + 1 }) %}
+                                                        {% if unit.location is not null %}
+                                                            {% set assigned_total = assigned_total + 1 %}
+                                                        {% endif %}
                                                     {% endfor %}
                                                 {% endif %}
 
@@ -138,9 +143,23 @@
                                                                 {{ loc }}: <span class="font-bold">{{ qty }}</span>
                                                             </span>
                                                         {% endif %}
-                                                    {% else %}
-                                                        <span class="text-muted small italic">Sin existencias en ubicaciones</span>
                                                     {% endfor %}
+
+                                                    {% if material.nature == 'CONSUMIBLE' and material.stock > assigned_total %}
+                                                        <span class="badge border font-normal bg-warning-subtle text-warning border-warning-subtle">
+                                                            <i data-lucide="alert-circle" class="w-2 h-2 inline me-0.5 opacity-50"></i>
+                                                            Pendiente Ubicación: <span class="font-bold">{{ material.stock - assigned_total }}</span>
+                                                        </span>
+                                                    {% elseif material.nature == 'EQUIPO_TECNICO' and material.units|length > assigned_total %}
+                                                        <span class="badge border font-normal bg-warning-subtle text-warning border-warning-subtle">
+                                                            <i data-lucide="alert-circle" class="w-2 h-2 inline me-0.5 opacity-50"></i>
+                                                            Sin Ubicación: <span class="font-bold">{{ material.units|length - assigned_total }}</span>
+                                                        </span>
+                                                    {% endif %}
+
+                                                    {% if loc_totals|length == 0 and assigned_total == 0 %}
+                                                        <span class="text-muted small italic">Sin existencias en ubicaciones</span>
+                                                    {% endif %}
                                                 </div>
                                             </td>
                                             <td>


### PR DESCRIPTION
- Resolved Twig syntax error in Material Index.
- Fixed TypeError in Excel import by converting DateTimeImmutable to DateTime.
- Implemented "Suggested Items" for Kit Templates, allowing items not yet in inventory.
- Populated "Mochila SVB Básica" template with 29 items and correct quantities.
- Improved Warehouse Dashboard: removed 15-item limit, added eager loading, and implemented "Pending Location" detection.
- Made subfamily filtering dynamic in Material Index based on database content.
- Ensured Sanitary materials default to Pharmacy warehouse.