### PR TITLE
Modernize Service creation form to match Material aesthetic

### DIFF
--- a/assets/controllers/sidebar_controller.js
+++ b/assets/controllers/sidebar_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
-    static targets = ["sidebar", "content", "submenu", "toggleIcon"];
+    static targets = ["sidebar", "content", "submenu", "toggleIcon", "mobileIcon"];
     static values = {
         collapsed: Boolean
     }
@@ -10,8 +10,32 @@ export default class extends Controller {
         const stored = localStorage.getItem('sidebar-collapsed');
         if (stored !== null) {
             this.collapsedValue = stored === 'true';
+        } else {
+            // Auto-collapse on small screens if no preference is stored
+            this.collapsedValue = window.innerWidth < 1024;
         }
+
         this._updateState();
+
+        // Listen for resize to auto-collapse/expand
+        this.resizeObserver = new ResizeObserver(() => {
+            this._handleResize();
+        });
+        this.resizeObserver.observe(document.body);
+    }
+
+    disconnect() {
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+        }
+    }
+
+    _handleResize() {
+        const shouldCollapse = window.innerWidth < 1024;
+        if (shouldCollapse !== this.collapsedValue) {
+            this.collapsedValue = shouldCollapse;
+            this._updateState();
+        }
     }
 
     toggleCollapse() {
@@ -58,6 +82,10 @@ export default class extends Controller {
                 this.toggleIconTarget.setAttribute('data-lucide', 'chevron-right');
             }
 
+            if (this.hasMobileIconTarget) {
+                this.mobileIconTarget.setAttribute('data-lucide', 'menu');
+            }
+
             this.submenuTargets.forEach(el => el.classList.remove('submenu-open'));
 
             const links = this.element.querySelectorAll('a[data-title]');
@@ -78,6 +106,10 @@ export default class extends Controller {
             if (this.hasToggleIconTarget) {
                 // Ensure the icon is chevron-left when expanded (to collapse)
                 this.toggleIconTarget.setAttribute('data-lucide', 'chevron-left');
+            }
+
+            if (this.hasMobileIconTarget) {
+                this.mobileIconTarget.setAttribute('data-lucide', 'x');
             }
 
             const links = this.element.querySelectorAll('a[data-title]');

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -218,21 +218,43 @@ html.dark #alertsDropdown i {
 
 /* Sidebar - Clases de utilidad se encargan del layout */
 .sidebar {
-    width: 260px !important;
-    transition: width 0.3s ease;
+    width: 260px;
+    transition: width 0.3s ease, transform 0.3s ease;
     background-color: var(--bg-main) !important;
 }
 
 .sidebar-collapsed {
-    width: 80px !important;
+    width: 80px;
 }
 
+/* Ocultar texto en sidebar contraído */
 .sidebar-collapsed .sidebar-text,
 .sidebar-collapsed .sidebar-header-text,
 .sidebar-collapsed .sidebar-section-title,
 .sidebar-collapsed .sidebar-header-container,
 .sidebar-collapsed .sidebar-user-info p {
     display: none !important;
+}
+
+/* Soporte Móvil (Responsive Extremo) */
+@media (max-width: 768px) {
+    .sidebar {
+        position: fixed;
+        left: 0;
+        top: 0;
+        height: 100vh;
+        z-index: 50;
+        box-shadow: 10px 0 30px rgba(0,0,0,0.1);
+    }
+
+    .sidebar-collapsed {
+        transform: translateX(-100%);
+        width: 260px; /* Mantener ancho completo cuando está visible pero "contraído" significa oculto en móvil */
+    }
+
+    .sidebar-collapsed-content {
+        margin-left: 0 !important;
+    }
 }
 
 .sidebar-collapsed .sidebar-item {

--- a/templates/layout/app.html.twig
+++ b/templates/layout/app.html.twig
@@ -3,6 +3,12 @@
 {% block body %}
 {% block page_title %}{% endblock %}
 <div class="flex h-screen w-full overflow-hidden m-0 p-0" data-controller="sidebar" data-sidebar-collapsed-value="false">
+    <!-- Mobile Toggle Button -->
+    <button data-action="click->sidebar#toggleCollapse"
+            class="hidden max-md:flex fixed bottom-6 right-6 w-14 h-14 bg-blue-600 text-white rounded-full shadow-2xl z-[60] items-center justify-center hover:bg-blue-700 transition-all active:scale-95">
+        <i data-lucide="menu" class="w-6 h-6" data-sidebar-target="mobileIcon"></i>
+    </button>
+
     <!-- Sidebar -->
     {% include 'layout/sidebar.html.twig' %}
     

--- a/templates/service/new.html.twig
+++ b/templates/service/new.html.twig
@@ -202,17 +202,17 @@
         }
     }) }}
 
-    <div class="mb-6 flex justify-between items-end">
+    <div class="mb-6 flex flex-col md:flex-row justify-between items-start md:items-end gap-4">
         <div>
             <h1 class="text-2xl font-black text-slate-900 dark:text-white mb-1">Crear Nuevo Servicio</h1>
             <p class="text-sm text-slate-500 dark:text-slate-400">Planificación y gestión de dispositivos preventivos</p>
         </div>
-        <div class="flex gap-3">
-            <a href="{{ path('app_services_list') }}" class="ui-btn btn-dark">
+        <div class="flex gap-2 w-full md:w-auto">
+            <a href="{{ path('app_services_list') }}" class="ui-btn btn-dark flex-1 md:flex-none">
                 <i data-lucide="x" class="w-4 h-4 mr-2"></i> Cancelar
             </a>
-            <button type="button" data-action="click->service-form#submitForm" class="ui-btn btn-cyan">
-                <i data-lucide="save" class="w-4 h-4 mr-2"></i> GUARDAR SERVICIO
+            <button type="button" data-action="click->service-form#submitForm" class="ui-btn btn-cyan flex-1 md:flex-none">
+                <i data-lucide="save" class="w-4 h-4 mr-2"></i> GUARDAR
             </button>
         </div>
     </div>
@@ -251,7 +251,7 @@
                             {{ form_widget(form.numeration, {'attr': {'class': 'ui-input font-mono !bg-slate-50 dark:!bg-slate-900', 'placeholder': 'Auto-generado si vacío', 'data-service-form-target': 'numeration'}}) }}
                         </div>
 
-                        <div class="grid grid-cols-2 gap-3 mb-6">
+                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
                             <div class="field-group !mb-0">
                                 <label class="field-label">Tipo <span>*</span></label>
                                 <div class="flex">
@@ -274,11 +274,11 @@
 
                         <div class="field-group !mb-0">
                             <label class="field-label">Afluencia Estimada <span>*</span></label>
-                            <div class="grid grid-cols-12 gap-2">
-                                <div class="col-span-8">
+                            <div class="grid grid-cols-1 sm:grid-cols-12 gap-2">
+                                <div class="sm:col-span-8">
                                     {{ form_widget(form.afluencia, {'attr': {'class': 'ui-input', 'data-action': 'change->service-form#updateAfluenciaColor', 'data-service-form-target': 'afluenciaSelect'}}) }}
                                 </div>
-                                <div class="col-span-4">
+                                <div class="sm:col-span-4">
                                     {{ form_widget(form.estimatedPeople, {'attr': {'class': 'ui-input text-center', 'placeholder': 'Nº aprox.', 'data-service-form-target': 'estimatedPeopleInput'}}) }}
                                 </div>
                             </div>
@@ -320,7 +320,7 @@
                             </div>
                         </div>
 
-                        <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+                        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                             <div class="date-input-container">
                                 <span class="date-badge">HORA EN BASE</span>
                                 <div class="ui-input-wrapper">
@@ -408,7 +408,7 @@
 
                     <!-- Dotación y Vehículos -->
                     <div class="lg:col-span-4">
-                        <div class="grid grid-cols-2 gap-6">
+                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
                             <!-- Personal -->
                             <div>
                                 <span class="block text-[10px] font-black text-slate-400 uppercase tracking-widest mb-4">Personal Requerido</span>


### PR DESCRIPTION
- Reorganized 'Nuevo Servicio' form into 'Datos Generales' and 'Recursos y Dotación' tabs.
- Implemented 'fieldset/legend' aesthetic with CSS variables for dark mode.
- Integrated Flatpickr for date/time fields with custom badge-style labels.
- Bundled TinyMCE plugins and skins via Vite to resolve asset 404/500 errors.
- Added responsive logic: sidebar auto-collapses at 1024px, fixed mobile drawer with FAB toggle.
- Enhanced form grid responsiveness for mobile and tablet viewports.
- Fixed public/index.php router to correctly serve static assets on local PHP server.